### PR TITLE
Fix bugs in population_seeds parameter

### DIFF
--- a/docs_sources/api.md
+++ b/docs_sources/api.md
@@ -7,6 +7,7 @@
                           <strong>subsample</strong>=1.0, <strong>n_jobs</strong>=1,
                           <strong>max_time_mins</strong>=None, <strong>max_eval_time_mins</strong>=5,
                           <strong>random_state</strong>=None, <strong>config_dict</strong>=None,
+                          <strong>population_seeds</strong>=None,
                           <strong>warm_start</strong>=False,
                           <strong>periodic_checkpoint_folder</strong>=None,
                           <strong>verbosity</strong>=0,
@@ -134,9 +135,23 @@ Possible inputs are:
 <li>Python dictionary, TPOT will use your custom configuration,</li>
 <li>string 'TPOT light', TPOT will use a built-in configuration with only fast models and preprocessors, or</li>
 <li>string 'TPOT MDR', TPOT will use a built-in configuration specialized for genomic studies, or</li>
+<li>string 'TPOT sparse': TPOT will use a configuration dictionary with a one-hot-encoder and the operators normally included in TPOT that also support sparse matrices, or</li>
 <li>None, TPOT will use the default TPOTClassifier configuration.</li>
 </ul>
 See the <a href="../using/#built-in-tpot-configurations">built-in configurations</a> section for the list of configurations included with TPOT, and the <a href="../using/#customizing-tpots-operators-and-parameters">custom configuration</a> section for more information and examples of how to create your own TPOT configurations.
+</blockquote>
+
+<strong>population_seeds</strong>: Python list, string, or None, optional (default=None)
+<blockquote>
+A configuration list for customizing a set of pipelines used in the first generation.
+<br /><br />
+Possible inputs are:
+<ul>
+<li>Python list, TPOT will use your custom population seeds,</li>
+<li>string, TPOT will use the path to a configuration file for customizing a set of pipelines used in the first generation, or</li>
+<li>None, TPOT won't any population seeds</li>
+</ul>
+See the the <a href="../using/#customizing-tpots-starting-population">starting population configuration</a> section for more information and examples of how to create your own starting population.
 </blockquote>
 
 <strong>warm_start</strong>: boolean, optional (default=False)
@@ -458,6 +473,7 @@ Does not return anything
                          <strong>subsample</strong>=1.0, <strong>n_jobs</strong>=1,
                          <strong>max_time_mins</strong>=None, <strong>max_eval_time_mins</strong>=5,
                          <strong>random_state</strong>=None, <strong>config_dict</strong>=None,
+                         <strong>population_seeds</strong>=None,
                          <strong>warm_start</strong>=False,
                          <strong>periodic_checkpoint_folder</strong>=None,
                          <strong>verbosity</strong>=0,
@@ -587,9 +603,23 @@ Possible inputs are:
 <li>Python dictionary, TPOT will use your custom configuration,</li>
 <li>string 'TPOT light', TPOT will use a built-in configuration with only fast models and preprocessors, or</li>
 <li>string 'TPOT MDR', TPOT will use a built-in configuration specialized for genomic studies, or</li>
+<li>string 'TPOT sparse': TPOT will use a configuration dictionary with a one-hot-encoder and the operators normally included in TPOT that also support sparse matrices, or</li>
 <li>None, TPOT will use the default TPOTRegressor configuration.</li>
 </ul>
 See the <a href="../using/#built-in-tpot-configurations">built-in configurations</a> section for the list of configurations included with TPOT, and the <a href="../using/#customizing-tpots-operators-and-parameters">custom configuration</a> section for more information and examples of how to create your own TPOT configurations.
+</blockquote>
+
+<strong>population_seeds</strong>: Python list, string, or None, optional (default=None)
+<blockquote>
+A configuration list for customizing a set of pipelines used in the first generation.
+<br /><br />
+Possible inputs are:
+<ul>
+<li>Python list, TPOT will use your custom population seeds,</li>
+<li>string, TPOT will use the path to a configuration file for customizing a set of pipelines used in the first generation, or</li>
+<li>None, TPOT won't any population seeds</li>
+</ul>
+See the the <a href="../using/#customizing-tpots-starting-population">starting population configuration</a> section for more information and examples of how to create your own starting population.
 </blockquote>
 
 <strong>warm_start</strong>: boolean, optional (default=False)

--- a/docs_sources/using.md
+++ b/docs_sources/using.md
@@ -557,7 +557,7 @@ If the `population_seeds` parameter is provided along with seeds from a configur
 
 # Crash/freeze issue with n_jobs > 1 under OSX or Linux
 
-TPOT allows parallel computing for speeding up optimization process, but it may suffers the crash/freeze issue with n_jobs > 1 under OSX or Linux [as  scikit-learn does](http://scikit-learn.org/stable/faq.html#why-do-i-sometime-get-a-crash-freeze-with-n-jobs-1-under-osx-or-linux), especially with large dataset. One solution is to configure Python `multiprocessing` to use the `forkserver` start methods (instead of the default `fork`) to manage the process pools. You may enable the `forkserver` mode globally for your program with putting the following codes into your main script:
+TPOT allows parallel computing for speeding up optimization process, but it may suffers the crash/freeze issue with n_jobs > 1 under OSX or Linux [as scikit-learn does](http://scikit-learn.org/stable/faq.html#why-do-i-sometime-get-a-crash-freeze-with-n-jobs-1-under-osx-or-linux), especially with large dataset. One solution is to configure Python `multiprocessing` to use the `forkserver` start methods (instead of the default `fork`) to manage the process pools. You may enable the `forkserver` mode globally for your program with putting the following codes into your main script:
 
 ```
 import multiprocessing

--- a/docs_sources/using.md
+++ b/docs_sources/using.md
@@ -265,6 +265,29 @@ Setting this parameter to higher values will allow TPOT to consider more complex
 Set this seed if you want your TPOT run to be reproducible with the same seed and data set in the future.</td>
 </tr>
 <tr>
+<td>-config</td>
+<td>CONFIG_FILE</td>
+<td>String or file path</td>
+<td>Operators and parameter configurations in TPOT:
+<br /><br />
+<ul>
+<li>Path for configuration file: TPOT will use the path to a configuration file for customizing the operators and parameters that TPOT uses in the optimization process</li>
+<li>string 'TPOT light', TPOT will use a built-in configuration with only fast models and preprocessors</li>
+<li>string 'TPOT MDR', TPOT will use a built-in configuration specialized for genomic studies</li>
+<li>string 'TPOT sparse': TPOT will use a configuration dictionary with a one-hot-encoder and the operators normally included in TPOT that also support sparse matrices.</li>
+</ul>
+See the <a href="../using/#built-in-tpot-configurations">built-in configurations</a> section for the list of configurations included with TPOT, and the <a href="../using/#customizing-tpots-operators-and-parameters">custom configuration</a> section for more information and examples of how to create your own TPOT configurations.
+</td>
+</tr>
+<tr>
+<td>-pseed</td>
+<td>POPULATION_SEEDS</td>
+<td>File path</td>
+<td>Configuration file for customizing a set of pipelines used in the first generation.
+<br /><br />
+See the the <a href="../using/#customizing-tpots-starting-population">starting population configuration</a> section for more information and examples of how to create your own starting population.
+</tr>
+<tr>
 <td>-cf</td>
 <td>CHECKPOINT_FOLDER</td>
 <td>Folder path</td>
@@ -366,6 +389,16 @@ TPOT comes with a handful of default operators and parameter configurations that
 <td align="center"><a href="https://github.com/rhiever/tpot/blob/master/tpot/config/classifier.py">Classification</a>
 <br /><br />
 <a href="https://github.com/rhiever/tpot/blob/master/tpot/config/regressor.py">Regression</a></td>
+</tr>
+
+<tr>
+<td>TPOT sparse</td>
+<td>TPOT uses a configuration dictionary with a one-hot-encoder and the operators normally included in TPOT that also support sparse matrices.
+<br /><br />
+This configuration works for both the TPOTClassifier and TPOTRegressor.</td>
+<td align="center"><a href="https://github.com/rhiever/tpot/blob/master/tpot/config/classifier_sparse.py">Classification</a>
+<br /><br />
+<a href="https://github.com/rhiever/tpot/blob/master/tpot/config/regressor_sparse.py">Regression</a></td>
 </tr>
 
 <tr>
@@ -483,18 +516,6 @@ Note that you must have all of the corresponding packages for the operators inst
 TPOT allows for the initial population of pipelines to be seeded. This can be done either through the `population_seeds` parameter in the TPOT constructor, or through a `population_seeds` attribute in a custom config file.
 
 ```Python
-population_seeds = [
-    'BernoulliNB(GaussianNB(input_matrix), BernoulliNB__alpha=0.1, BernoulliNB__fit_prior=False)',
-    'BernoulliNB(input_matrix, BernoulliNB__alpha=0.01, BernoulliNB__fit_prior=True)'
-]
-
-tpot = TPOTClassifier(generations=5, population_size=20, verbosity=2,
-                      config_dict=tpot_config, population_seeds=population_seeds)
-```
-
-If specified through a config file, your config file would look like this:
-
-```Python
 tpot_config = {
     'sklearn.naive_bayes.GaussianNB': {
     },
@@ -511,6 +532,18 @@ tpot_config = {
 }
 
 population_seeds = [
+    'BernoulliNB(input_matrix, BernoulliNB__alpha=0.1, BernoulliNB__fit_prior=False)',
+    'BernoulliNB(input_matrix, BernoulliNB__alpha=0.01, BernoulliNB__fit_prior=True)'
+]
+
+tpot = TPOTClassifier(generations=5, population_size=20, verbosity=2,
+                      config_dict=tpot_config, population_seeds=population_seeds)
+```
+
+If specified through a config file, your config file would look like this:
+
+```
+population_seeds = [
     'BernoulliNB(GaussianNB(input_matrix), BernoulliNB__alpha=0.1, BernoulliNB__fit_prior=False)',
     'BernoulliNB(input_matrix, BernoulliNB__alpha=0.01, BernoulliNB__fit_prior=True)'
 ]
@@ -522,7 +555,7 @@ If less seeds are provided than there are to be individuals in the entire popula
 
 If the `population_seeds` parameter is provided along with seeds from a configuration file, the configuration file's seeds will take precedence.
 
-**Crash/freeze issue with n_jobs > 1 under OSX or Linux**
+# Crash/freeze issue with n_jobs > 1 under OSX or Linux
 
 TPOT allows parallel computing for speeding up optimization process, but it may suffers the crash/freeze issue with n_jobs > 1 under OSX or Linux [as  scikit-learn does](http://scikit-learn.org/stable/faq.html#why-do-i-sometime-get-a-crash-freeze-with-n-jobs-1-under-osx-or-linux), especially with large dataset. One solution is to configure Python `multiprocessing` to use the `forkserver` start methods (instead of the default `fork`) to manage the process pools. You may enable the `forkserver` mode globally for your program with putting the following codes into your main script:
 

--- a/docs_sources/using.md
+++ b/docs_sources/using.md
@@ -542,7 +542,7 @@ tpot = TPOTClassifier(generations=5, population_size=20, verbosity=2,
 
 If specified through a config file, your config file would look like this:
 
-```
+```Python
 population_seeds = [
     'BernoulliNB(GaussianNB(input_matrix), BernoulliNB__alpha=0.1, BernoulliNB__fit_prior=False)',
     'BernoulliNB(input_matrix, BernoulliNB__alpha=0.01, BernoulliNB__fit_prior=True)'
@@ -559,7 +559,7 @@ If the `population_seeds` parameter is provided along with seeds from a configur
 
 TPOT allows parallel computing for speeding up optimization process, but it may suffers the crash/freeze issue with n_jobs > 1 under OSX or Linux [as scikit-learn does](http://scikit-learn.org/stable/faq.html#why-do-i-sometime-get-a-crash-freeze-with-n-jobs-1-under-osx-or-linux), especially with large dataset. One solution is to configure Python `multiprocessing` to use the `forkserver` start methods (instead of the default `fork`) to manage the process pools. You may enable the `forkserver` mode globally for your program with putting the following codes into your main script:
 
-```
+```Python
 import multiprocessing
 
 # other imports, custom code, load data, define model...

--- a/tests/driver_tests.py
+++ b/tests/driver_tests.py
@@ -220,6 +220,7 @@ class ParserTest(TestCase):
         """Assert that the TPOT driver stores correct default values for all parameters."""
         args = self.parser.parse_args(['tests/tests.csv'])
         self.assertEqual(args.CONFIG_FILE, None)
+        self.assertEqual(args.POPULATION_SEEDS, None)
         self.assertEqual(args.CROSSOVER_RATE, 0.1)
         self.assertEqual(args.EARLY_STOP, None)
         self.assertEqual(args.DISABLE_UPDATE_CHECK, False)
@@ -263,6 +264,7 @@ NUM_JOBS\t=\t1
 OFFSPRING_SIZE\t=\t100
 CHECKPOINT_FOLDER\t=\tNone
 OUTPUT_FILE\t=\t
+POPULATION_SEEDS\t=\tNone
 POPULATION_SIZE\t=\t100
 RANDOM_STATE\t=\tNone
 SCORING_FN\t=\taccuracy
@@ -302,6 +304,7 @@ NUM_JOBS\t=\t1
 OFFSPRING_SIZE\t=\t100
 CHECKPOINT_FOLDER\t=\tNone
 OUTPUT_FILE\t=\t
+POPULATION_SEEDS\t=\tNone
 POPULATION_SIZE\t=\t100
 RANDOM_STATE\t=\tNone
 SCORING_FN\t=\tneg_mean_squared_error

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -355,6 +355,70 @@ def test_conf_dict_5():
     assert len(tpot_obj._pop) == n_seeds
 
 
+def test_population_seeds():
+    """Assert that population_seeds takes python list as input."""
+    pipeline_string_1 = (
+        'DecisionTreeClassifier('
+        'input_matrix, '
+        'DecisionTreeClassifier__criterion=gini, '
+        'DecisionTreeClassifier__max_depth=8, '
+        'DecisionTreeClassifier__min_samples_leaf=5, '
+        'DecisionTreeClassifier__min_samples_split=5'
+        ')'
+    )
+    pipeline_string_2 = (
+        'KNeighborsClassifier('
+        'input_matrix, '
+        'KNeighborsClassifier__n_neighbors=10, '
+        'KNeighborsClassifier__p=1, '
+        'KNeighborsClassifier__weights=uniform'
+        ')'
+    )
+    pseeds = [pipeline_string_1, pipeline_string_2]
+    tpot_obj = TPOTClassifier(
+            random_state=42,
+            population_size=3,
+            generations=0,
+            population_seeds=pseeds,
+            verbosity=0,
+            cv=3
+        )
+    tpot_obj.fit(training_features, training_target)
+    assert isinstance(tpot_obj._optimized_pipeline, creator.Individual)
+
+
+def test_population_seeds_2():
+    """Assert that population_seeds takes python list as input and population_size is not larger than population_seeds"""
+    pipeline_string_1 = (
+        'DecisionTreeClassifier('
+        'input_matrix, '
+        'DecisionTreeClassifier__criterion=gini, '
+        'DecisionTreeClassifier__max_depth=8, '
+        'DecisionTreeClassifier__min_samples_leaf=5, '
+        'DecisionTreeClassifier__min_samples_split=5'
+        ')'
+    )
+    pipeline_string_2 = (
+        'KNeighborsClassifier('
+        'input_matrix, '
+        'KNeighborsClassifier__n_neighbors=10, '
+        'KNeighborsClassifier__p=1, '
+        'KNeighborsClassifier__weights=uniform'
+        ')'
+    )
+    pseeds = [pipeline_string_1, pipeline_string_2]
+    tpot_obj = TPOTClassifier(
+            random_state=42,
+            population_size=2,
+            generations=0,
+            population_seeds=pseeds,
+            verbosity=0,
+            cv=3
+        )
+    tpot_obj.fit(training_features, training_target)
+    assert isinstance(tpot_obj._optimized_pipeline, creator.Individual)
+
+
 def test_read_config_file():
     """Assert that _read_config_file rasies FileNotFoundError with a wrong path."""
     tpot_obj = TPOTRegressor()

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -1584,8 +1584,8 @@ def test_mutNodeReplacement():
     old_ret_type_list = [node.ret for node in pipeline]
     old_prims_list = [node for node in pipeline if node.arity != 0]
 
-    # test 10 times
-    for _ in range(10):
+    # test 20 times
+    for _ in range(20):
         mut_ind = mutNodeReplacement(tpot_obj._toolbox.clone(pipeline), pset=tpot_obj._pset)
         new_ret_type_list = [node.ret for node in mut_ind[0]]
         new_prims_list = [node for node in mut_ind[0] if node.arity != 0]

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -1573,27 +1573,17 @@ def test_mutNodeReplacement():
     """Assert that mutNodeReplacement() returns the correct type of mutation node in a fixed pipeline."""
     tpot_obj = TPOTClassifier()
     pipeline_string = (
-        'KNeighborsClassifier(CombineDFs('
-        'DecisionTreeClassifier(input_matrix, '
-        'DecisionTreeClassifier__criterion=gini, '
-        'DecisionTreeClassifier__max_depth=8, '
-        'DecisionTreeClassifier__min_samples_leaf=5, '
-        'DecisionTreeClassifier__min_samples_split=5'
-        '), '
-        'SelectPercentile('
-        'input_matrix, '
-        'SelectPercentile__percentile=20'
-        ')'
-        'KNeighborsClassifier__n_neighbors=10, '
-        'KNeighborsClassifier__p=1, '
-        'KNeighborsClassifier__weights=uniform'
-        ')'
+        'LogisticRegression(PolynomialFeatures'
+        '(input_matrix, PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=False, '
+        'PolynomialFeatures__interaction_only=False), LogisticRegression__C=10.0, '
+        'LogisticRegression__dual=False, LogisticRegression__penalty=l2)'
     )
 
     pipeline = creator.Individual.from_string(pipeline_string, tpot_obj._pset)
     pipeline[0].ret = Output_Array
     old_ret_type_list = [node.ret for node in pipeline]
     old_prims_list = [node for node in pipeline if node.arity != 0]
+
     # test 10 times
     for _ in range(10):
         mut_ind = mutNodeReplacement(tpot_obj._toolbox.clone(pipeline), pset=tpot_obj._pset)
@@ -1604,8 +1594,8 @@ def test_mutNodeReplacement():
             assert new_ret_type_list == old_ret_type_list
         else:  # Primitive mutated
             diff_prims = list(set(new_prims_list).symmetric_difference(old_prims_list))
-            assert diff_prims[0].ret == diff_prims[1].ret
-
+            if len(diff_prims) > 1: # Sometimes mutation randomly replaces an operator that already in the pipelines
+                assert diff_prims[0].ret == diff_prims[1].ret
         assert mut_ind[0][0].ret == Output_Array
 
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -338,9 +338,10 @@ def test_conf_dict_3():
     assert isinstance(tpot_obj.config_dict, dict)
     assert tpot_obj.config_dict == tested_config_dict
 
+
 def test_conf_dict_4():
     """Assert that TPOT uses seeds from custom dictionary as the starting population."""
-    tpot_obj = TPOTRegressor(config_dict='tests/test_config.py', generations=1, population_size=10)
+    tpot_obj = TPOTRegressor(config_dict='tests/test_config.py', population_seeds='tests/test_config.py', generations=1, population_size=10)
 
     assert isinstance(tpot_obj._pop, list)
     assert isinstance(tpot_obj._pop[0], creator.Individual)
@@ -348,23 +349,56 @@ def test_conf_dict_4():
 
 def test_conf_dict_5():
     """Assert that TPOT has a _pop attribute of the same size as the number of seeds provided."""
-    tpot_obj = TPOTRegressor(config_dict='tests/test_config.py')
+    tpot_obj = TPOTRegressor(config_dict='tests/test_config.py', population_seeds='tests/test_config.py')
     n_seeds = len(tpot_obj._read_config_file('tests/test_config.py').population_seeds)
 
     assert len(tpot_obj._pop) == n_seeds
 
 
 def test_read_config_file():
-    """Assert that _read_config_file rasie FileNotFoundError with a wrong path."""
+    """Assert that _read_config_file rasies FileNotFoundError with a wrong path."""
     tpot_obj = TPOTRegressor()
     # typo for "tests/test_config.py"
     assert_raises(ValueError, tpot_obj._read_config_file, "tests/test_confg.py")
 
 
 def test_read_config_file_2():
-    """Assert that _read_config_file rasie ValueError with wrong dictionary format"""
+    """Assert that _read_config_file rasies ValueError with wrong dictionary format"""
     tpot_obj = TPOTRegressor()
     assert_raises(ValueError, tpot_obj._read_config_file, "tests/test_config.py.bad")
+
+
+def test_read_config_file_3():
+    """Assert that _read_config_file rasies ValueError without a dictionary named 'tpot_config'."""
+    tpot_obj = TPOTRegressor()
+    assert_raises(ValueError, tpot_obj._setup_config, "tpot/config/regressor_sparse.py")
+
+
+def test_setup_pop():
+    """Assert that _setup_pop rasies ValueError without a dictionary named 'population_seeds'."""
+    tpot_obj = TPOTRegressor()
+    assert_raises(ValueError, tpot_obj._setup_pop, "tpot/config/regressor_sparse.py")
+
+
+def test_setup_pop_2():
+    """Assert that _setup_pop will not rasie ValueError with a python list"""
+    tpot_obj = TPOTRegressor()
+
+    pipeline_string = (
+        "ExtraTreesRegressor("
+        "GradientBoostingRegressor(input_matrix, GradientBoostingRegressor__alpha=0.8,"
+        "GradientBoostingRegressor__learning_rate=0.1,GradientBoostingRegressor__loss=huber,"
+        "GradientBoostingRegressor__max_depth=5, GradientBoostingRegressor__max_features=0.5,"
+        "GradientBoostingRegressor__min_samples_leaf=5, GradientBoostingRegressor__min_samples_split=5,"
+        "GradientBoostingRegressor__n_estimators=100, GradientBoostingRegressor__subsample=0.25),"
+        "ExtraTreesRegressor__bootstrap=True, ExtraTreesRegressor__max_features=0.5,"
+        "ExtraTreesRegressor__min_samples_leaf=5, ExtraTreesRegressor__min_samples_split=5, "
+        "ExtraTreesRegressor__n_estimators=100)"
+    )
+    assert tpot_obj._pop == []
+
+    tpot_obj._setup_pop([pipeline_string])
+    assert len(tpot_obj._pop) == 1
 
 
 def test_random_ind():

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -186,8 +186,12 @@ class TPOTBase(BaseEstimator):
             String 'TPOT sparse':
                 TPOT uses a configuration dictionary with a one-hot-encoder and the
                 operators normally included in TPOT that also support sparse matrices.
-        population_seeds: list of strings, optional (Default: None)
-            The set of pipelines used in the first generation.
+        population_seeds: a Python list or a string, optional (Default: None)
+            Python list:
+                A list customizing a set of pipelines used in the first generation.
+            Path for configuration file:
+                A path to a configuration file for customizing a set of pipelines used in
+                the first generation.
         warm_start: bool, optional (default: False)
             Flag indicating whether the TPOT instance will reuse the population from
             previous calls to fit().
@@ -253,7 +257,8 @@ class TPOTBase(BaseEstimator):
         else:
             self.offspring_size = population_size
 
-        self._setup_config(config_dict)
+        self.config_dict_params=config_dict
+        self._setup_config(self.config_dict_params)
 
         self.operators = []
         self.arguments = []
@@ -330,7 +335,7 @@ class TPOTBase(BaseEstimator):
 
         self._setup_pset()
         self._setup_toolbox()
-        self._setup_pop(population_seeds, config_dict)
+        self._setup_pop(population_seeds)
 
 
     def _setup_config(self, config_dict):
@@ -353,7 +358,16 @@ class TPOTBase(BaseEstimator):
                 else:
                     self.config_dict = regressor_config_sparse
             else:
-                self.config_dict = self._read_config_file(config_dict).tpot_config
+                config = self._read_config_file(config_dict)
+                if hasattr(config, 'tpot_config'):
+                    self.config_dict = config.tpot_config
+                else:
+                    raise ValueError(
+                                    'Could not find "tpot_config" in configuration file {}. '
+                                    'When using a custom config file for customizing operators '
+                                    'dictionary, the file must have a python dictionary with '
+                                    'the standardized name of "tpot_config"'.format(config_dict)
+                                    )
         else:
             self.config_dict = self.default_config_dict
 
@@ -379,18 +393,24 @@ class TPOTBase(BaseEstimator):
             )
 
 
-    def _setup_pop(self, population_seeds, config_path):
+    def _setup_pop(self, population_seeds):
         """If the population_seeds are specified, use them as the starting population."""
-        try:
-            config = self._read_config_file(config_path)
+        if population_seeds:
+            if not isinstance(population_seeds, list):
+                config = self._read_config_file(population_seeds)
+                if hasattr(config, 'population_seeds'):
+                    pop_seeds = config.population_seeds
+                else:
+                    raise ValueError(
+                                    'Could not find "population_seeds" in configuration file {}. '
+                                    'When using a custom config file for customizing the seeds, '
+                                    'the file must have a list of strings with the standardized '
+                                    'name of "population_seeds"'.format(population_seeds)
+                                    )
+            else:
+                pop_seeds = population_seeds
 
-            if hasattr(config, 'population_seeds'):
-                population_seeds = config.population_seeds
-        except Exception as e:
-            # Config isn't a file
-            return
-
-        self._pop = [creator.Individual.from_string(x, self._pset) for x in population_seeds]
+            self._pop = [creator.Individual.from_string(x, self._pset) for x in pop_seeds]
 
 
     def _setup_pset(self):

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -551,6 +551,8 @@ class TPOTBase(BaseEstimator):
         n_left_to_generate = self.population_size - len(self._pop)
         if n_left_to_generate > 0:
             pop = self._pop + self._toolbox.population(n=n_left_to_generate)
+        else:
+            pop = self._pop
 
         def pareto_eq(ind1, ind2):
             """Determine whether two individuals are equal on the Pareto front.

--- a/tpot/driver.py
+++ b/tpot/driver.py
@@ -335,6 +335,7 @@ def _get_arg_parser():
         )
     )
 
+
     parser.add_argument(
         '-config',
         action='store',
@@ -348,6 +349,20 @@ def _get_arg_parser():
             'built-in configuration.'
         )
     )
+
+
+    parser.add_argument(
+        '-pseed',
+        action='store',
+        dest='POPULATION_SEEDS',
+        default=None,
+        type=str,
+        help=(
+            'Configuration file for customizing a set of pipelines used in '
+            'the first generation.'
+        )
+    )
+
 
     parser.add_argument(
         '-cf',
@@ -496,6 +511,7 @@ def tpot_driver(args):
         max_eval_time_mins=args.MAX_EVAL_MINS,
         random_state=args.RANDOM_STATE,
         config_dict=args.CONFIG_FILE,
+        population_seeds=args.POPULATION_SEEDS,
         periodic_checkpoint_folder=args.CHECKPOINT_FOLDER,
         early_stop=args.EARLY_STOP,
         verbosity=args.VERBOSITY,


### PR DESCRIPTION
[please review the [contribution guidelines](http://rhiever.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

Current TPOT dev only take config file but doesn't take python list for customizing population seeds. And this parameter also has conflicts with `config_dict`. For example, if assigning a configuration file to `config_dict`, TPOT will raise `Exception` if no `population_seeds` list in the file. This PR: 

1. Fixed the conflicts with `config_dict`

2. Added more checks for both `config_dict` and `population_seeds`

3. Added more unit tests for both parameters

4. Update driver for using population seeds in CLI

5. Update using.md and api.md for `population_seeds`

6. Fix a bug in fit() that causes initial pop in GP cannot be generated if population_seeds is larger than population_size

7. clean codes



## Questions:

- Do the docs need to be updated? No
- Does this PR add new (Python) dependencies? No
