### PR TITLE
Add support for sparse matrix

### DIFF
--- a/docs_sources/using.md
+++ b/docs_sources/using.md
@@ -478,49 +478,6 @@ For more detailed examples of how to customize TPOT's operator configuration, se
 
 Note that you must have all of the corresponding packages for the operators installed on your computer, otherwise TPOT will not be able to use them. For example, if XGBoost is not installed on your computer, then TPOT will simply not import nor use XGBoost in the pipelines it considers.
 
-# Customizing TPOT's starting population
-
-TPOT allows for the initial population of pipelines to be seeded. This can be done either through the `population_seeds` parameter in the TPOT constructor, or through a `population_seeds` attribute in a custom config file.
-
-```Python
-population_seeds = [
-    'BernoulliNB(GaussianNB(input_matrix), BernoulliNB__alpha=0.1, BernoulliNB__fit_prior=False)',
-    'BernoulliNB(input_matrix, BernoulliNB__alpha=0.01, BernoulliNB__fit_prior=True)'
-]
-
-tpot = TPOTClassifier(generations=5, population_size=20, verbosity=2,
-                      config_dict=tpot_config, population_seeds=population_seeds)
-```
-
-If specified through a config file, your config file would look like this:
-
-```Python
-tpot_config = {
-    'sklearn.naive_bayes.GaussianNB': {
-    },
-
-    'sklearn.naive_bayes.BernoulliNB': {
-        'alpha': [1e-3, 1e-2, 1e-1, 1., 10., 100.],
-        'fit_prior': [True, False]
-    },
-
-    'sklearn.naive_bayes.MultinomialNB': {
-        'alpha': [1e-3, 1e-2, 1e-1, 1., 10., 100.],
-        'fit_prior': [True, False]
-    }
-}
-
-population_seeds = [
-    'BernoulliNB(GaussianNB(input_matrix), BernoulliNB__alpha=0.1, BernoulliNB__fit_prior=False)',
-    'BernoulliNB(input_matrix, BernoulliNB__alpha=0.01, BernoulliNB__fit_prior=True)'
-]
-```
-
-As with `tpot_config`, when using a custom config file the seeds *must* have the standardized name of "population_seeds". It should only ever be a list of strings.
-
-If less seeds are provided than there are to be individuals in the entire population, then the remainder will be filled with random individuals.
-
-If the `population_seeds` parameter is provided along with seeds from a configuration file, the configuration file's seeds will take precedence.
 
 **Crash/freeze issue with n_jobs > 1 under OSX or Linux**
 

--- a/tests/driver_tests.py
+++ b/tests/driver_tests.py
@@ -220,7 +220,6 @@ class ParserTest(TestCase):
         """Assert that the TPOT driver stores correct default values for all parameters."""
         args = self.parser.parse_args(['tests/tests.csv'])
         self.assertEqual(args.CONFIG_FILE, None)
-        self.assertEqual(args.POPULATION_SEEDS, None)
         self.assertEqual(args.CROSSOVER_RATE, 0.1)
         self.assertEqual(args.EARLY_STOP, None)
         self.assertEqual(args.DISABLE_UPDATE_CHECK, False)
@@ -264,7 +263,6 @@ NUM_JOBS\t=\t1
 OFFSPRING_SIZE\t=\t100
 CHECKPOINT_FOLDER\t=\tNone
 OUTPUT_FILE\t=\t
-POPULATION_SEEDS\t=\tNone
 POPULATION_SIZE\t=\t100
 RANDOM_STATE\t=\tNone
 SCORING_FN\t=\taccuracy
@@ -304,7 +302,6 @@ NUM_JOBS\t=\t1
 OFFSPRING_SIZE\t=\t100
 CHECKPOINT_FOLDER\t=\tNone
 OUTPUT_FILE\t=\t
-POPULATION_SEEDS\t=\tNone
 POPULATION_SIZE\t=\t100
 RANDOM_STATE\t=\tNone
 SCORING_FN\t=\tneg_mean_squared_error

--- a/tests/driver_tests.py
+++ b/tests/driver_tests.py
@@ -220,6 +220,7 @@ class ParserTest(TestCase):
         """Assert that the TPOT driver stores correct default values for all parameters."""
         args = self.parser.parse_args(['tests/tests.csv'])
         self.assertEqual(args.CONFIG_FILE, None)
+        self.assertEqual(args.POPULATION_SEEDS, None)
         self.assertEqual(args.CROSSOVER_RATE, 0.1)
         self.assertEqual(args.EARLY_STOP, None)
         self.assertEqual(args.DISABLE_UPDATE_CHECK, False)
@@ -263,6 +264,7 @@ NUM_JOBS\t=\t1
 OFFSPRING_SIZE\t=\t100
 CHECKPOINT_FOLDER\t=\tNone
 OUTPUT_FILE\t=\t
+POPULATION_SEEDS\t=\tNone
 POPULATION_SIZE\t=\t100
 RANDOM_STATE\t=\tNone
 SCORING_FN\t=\taccuracy
@@ -302,6 +304,7 @@ NUM_JOBS\t=\t1
 OFFSPRING_SIZE\t=\t100
 CHECKPOINT_FOLDER\t=\tNone
 OUTPUT_FILE\t=\t
+POPULATION_SEEDS\t=\tNone
 POPULATION_SIZE\t=\t100
 RANDOM_STATE\t=\tNone
 SCORING_FN\t=\tneg_mean_squared_error

--- a/tests/export_tests.py
+++ b/tests/export_tests.py
@@ -553,7 +553,7 @@ features = tpot_data.drop('target', axis=1).values
 training_features, testing_features, training_target, testing_target = \\
             train_test_split(features, tpot_data['target'].values, random_state=42)
 
-imputer = Imputer(strategy="median", axis=0)
+imputer = Imputer(strategy="median")
 imputer.fit(training_features)
 training_features = imputer.transform(training_features)
 testing_features = imputer.transform(testing_features)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,8 +33,3 @@ tpot_config = {
         'fit_prior': [True, False]
     }
 }
-
-population_seeds = [
-    'BernoulliNB(input_matrix, BernoulliNB__alpha=0.1, BernoulliNB__fit_prior=False)',
-    'BernoulliNB(input_matrix, BernoulliNB__alpha=0.01, BernoulliNB__fit_prior=True)'
-]

--- a/tests/test_config_sparse.py
+++ b/tests/test_config_sparse.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+"""Copyright 2015-Present Randal S. Olson.
+
+This file is part of the TPOT library.
+
+TPOT is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+TPOT is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+import numpy as np
+
+tpot_config = {
+    'sklearn.neighbors.KNeighborsClassifier': {
+        'n_neighbors': range(1, 101),
+        'weights': ["uniform", "distance"],
+        'p': [1, 2]
+    },
+
+    'sklearn.ensemble.RandomForestClassifier': {
+        'n_estimators': [100],
+        'criterion': ["gini", "entropy"],
+        'max_features': np.arange(0.05, 1.01, 0.05),
+        'min_samples_split': range(2, 21),
+        'min_samples_leaf':  range(1, 21),
+        'bootstrap': [True, False]
+    }
+}

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -338,13 +338,6 @@ def test_conf_dict_3():
     assert isinstance(tpot_obj.config_dict, dict)
     assert tpot_obj.config_dict == tested_config_dict
 
-def test_conf_dict_4():
-    """Assert that TPOT uses seeds from custom dictionary as the starting population."""
-    tpot_obj = TPOTRegressor(config_dict='tests/test_config.py', generations=1, population_size=10)
-
-    assert isinstance(tpot_obj._pop, list)
-    assert isinstance(tpot_obj._pop[0], creator.Individual)
-
 
 def test_read_config_file():
     """Assert that _read_config_file rasie FileNotFoundError with a wrong path."""

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -36,6 +36,7 @@ from tpot.config.regressor_sparse import regressor_config_sparse
 from tpot.config.classifier_sparse import classifier_config_sparse
 
 import numpy as np
+from scipy import sparse
 import inspect
 import random
 from multiprocessing import cpu_count
@@ -75,6 +76,10 @@ training_features, testing_features, training_target, testing_target = \
 boston_data = load_boston()
 training_features_r, testing_features_r, training_target_r, testing_target_r = \
     train_test_split(boston_data.data, boston_data.target, random_state=42)
+
+# Set up the sparse matrix for testing
+sparse_features = sparse.csr_matrix(training_features)
+sparse_target = training_target
 
 np.random.seed(42)
 random.seed(42)
@@ -1293,6 +1298,76 @@ def test_imputer_3():
         assert_in("Imputing missing values in feature set", out.getvalue())
 
     assert_not_equal(imputed_features[0][0], float('nan'))
+
+
+def test_sparse_matrix():
+    """Assert that the TPOT fit function will raise a ValueError in a sparse matrix with config_dict='TPOT light'."""
+    tpot_obj = TPOTClassifier(
+        random_state=42,
+        population_size=1,
+        offspring_size=2,
+        generations=1,
+        verbosity=0,
+        config_dict='TPOT light'
+    )
+
+    assert_raises(ValueError, tpot_obj.fit, sparse_features, sparse_target)
+
+
+def test_sparse_matrix_2():
+    """Assert that the TPOT fit function will raise a ValueError in a sparse matrix with config_dict=None."""
+    tpot_obj = TPOTClassifier(
+        random_state=42,
+        population_size=1,
+        offspring_size=2,
+        generations=1,
+        verbosity=0,
+        config_dict=None
+    )
+
+    assert_raises(ValueError, tpot_obj.fit, sparse_features, sparse_target)
+
+
+def test_sparse_matrix_3():
+    """Assert that the TPOT fit function will raise a ValueError in a sparse matrix with config_dict='TPOT MDR'."""
+    tpot_obj = TPOTClassifier(
+        random_state=42,
+        population_size=1,
+        offspring_size=2,
+        generations=1,
+        verbosity=0,
+        config_dict='TPOT MDR'
+    )
+
+    assert_raises(ValueError, tpot_obj.fit, sparse_features, sparse_target)
+
+
+def test_sparse_matrix_4():
+    """Assert that the TPOT fit function will not raise a ValueError in a sparse matrix with config_dict='TPOT sparse'."""
+    tpot_obj = TPOTClassifier(
+        random_state=42,
+        population_size=1,
+        offspring_size=2,
+        generations=1,
+        verbosity=0,
+        config_dict='TPOT sparse'
+    )
+
+    tpot_obj.fit(sparse_features, sparse_target)
+
+
+def test_sparse_matrix_5():
+    """Assert that the TPOT fit function will not raise a ValueError in a sparse matrix with a customized config dictionary."""
+    tpot_obj = TPOTClassifier(
+        random_state=42,
+        population_size=1,
+        offspring_size=2,
+        generations=1,
+        verbosity=0,
+        config_dict='tests/test_config_sparse.py'
+    )
+
+    tpot_obj.fit(sparse_features, sparse_target)
 
 
 def test_tpot_operator_factory_class():

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -1584,27 +1584,17 @@ def test_mutNodeReplacement():
     """Assert that mutNodeReplacement() returns the correct type of mutation node in a fixed pipeline."""
     tpot_obj = TPOTClassifier()
     pipeline_string = (
-        'KNeighborsClassifier(CombineDFs('
-        'DecisionTreeClassifier(input_matrix, '
-        'DecisionTreeClassifier__criterion=gini, '
-        'DecisionTreeClassifier__max_depth=8, '
-        'DecisionTreeClassifier__min_samples_leaf=5, '
-        'DecisionTreeClassifier__min_samples_split=5'
-        '), '
-        'SelectPercentile('
-        'input_matrix, '
-        'SelectPercentile__percentile=20'
-        ')'
-        'KNeighborsClassifier__n_neighbors=10, '
-        'KNeighborsClassifier__p=1, '
-        'KNeighborsClassifier__weights=uniform'
-        ')'
+        'LogisticRegression(PolynomialFeatures'
+        '(input_matrix, PolynomialFeatures__degree=2, PolynomialFeatures__include_bias=False, '
+        'PolynomialFeatures__interaction_only=False), LogisticRegression__C=10.0, '
+        'LogisticRegression__dual=False, LogisticRegression__penalty=l2)'
     )
 
     pipeline = creator.Individual.from_string(pipeline_string, tpot_obj._pset)
     pipeline[0].ret = Output_Array
     old_ret_type_list = [node.ret for node in pipeline]
     old_prims_list = [node for node in pipeline if node.arity != 0]
+
     # test 10 times
     for _ in range(10):
         mut_ind = mutNodeReplacement(tpot_obj._toolbox.clone(pipeline), pset=tpot_obj._pset)
@@ -1615,8 +1605,8 @@ def test_mutNodeReplacement():
             assert new_ret_type_list == old_ret_type_list
         else:  # Primitive mutated
             diff_prims = list(set(new_prims_list).symmetric_difference(old_prims_list))
-            assert diff_prims[0].ret == diff_prims[1].ret
-
+            if len(diff_prims) > 1: # Sometimes mutation randomly replaces an operator that already in the pipelines
+                assert diff_prims[0].ret == diff_prims[1].ret
         assert mut_ind[0][0].ret == Output_Array
 
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -363,33 +363,6 @@ def test_read_config_file_3():
     assert_raises(ValueError, tpot_obj._setup_config, "tpot/config/regressor_sparse.py")
 
 
-def test_setup_pop():
-    """Assert that _setup_pop rasies ValueError without a dictionary named 'population_seeds'."""
-    tpot_obj = TPOTRegressor()
-    assert_raises(ValueError, tpot_obj._setup_pop, "tpot/config/regressor_sparse.py")
-
-
-def test_setup_pop_2():
-    """Assert that _setup_pop will not rasie ValueError with a python list"""
-    tpot_obj = TPOTRegressor()
-
-    pipeline_string = (
-        "ExtraTreesRegressor("
-        "GradientBoostingRegressor(input_matrix, GradientBoostingRegressor__alpha=0.8,"
-        "GradientBoostingRegressor__learning_rate=0.1,GradientBoostingRegressor__loss=huber,"
-        "GradientBoostingRegressor__max_depth=5, GradientBoostingRegressor__max_features=0.5,"
-        "GradientBoostingRegressor__min_samples_leaf=5, GradientBoostingRegressor__min_samples_split=5,"
-        "GradientBoostingRegressor__n_estimators=100, GradientBoostingRegressor__subsample=0.25),"
-        "ExtraTreesRegressor__bootstrap=True, ExtraTreesRegressor__max_features=0.5,"
-        "ExtraTreesRegressor__min_samples_leaf=5, ExtraTreesRegressor__min_samples_split=5, "
-        "ExtraTreesRegressor__n_estimators=100)"
-    )
-    assert tpot_obj._pop == []
-
-    tpot_obj._setup_pop([pipeline_string])
-    assert len(tpot_obj._pop) == 1
-
-
 def test_random_ind():
     """Assert that the TPOTClassifier can generate the same pipeline with same random seed."""
     tpot_obj = TPOTClassifier(random_state=43)

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -346,14 +346,6 @@ def test_conf_dict_4():
     assert isinstance(tpot_obj._pop[0], creator.Individual)
 
 
-def test_conf_dict_5():
-    """Assert that TPOT has a _pop attribute of the same size as the number of seeds provided."""
-    tpot_obj = TPOTRegressor(config_dict='tests/test_config.py')
-    n_seeds = len(tpot_obj._read_config_file('tests/test_config.py').population_seeds)
-
-    assert len(tpot_obj._pop) == n_seeds
-
-
 def test_read_config_file():
     """Assert that _read_config_file rasie FileNotFoundError with a wrong path."""
     tpot_obj = TPOTRegressor()

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -338,9 +338,10 @@ def test_conf_dict_3():
     assert isinstance(tpot_obj.config_dict, dict)
     assert tpot_obj.config_dict == tested_config_dict
 
+
 def test_conf_dict_4():
     """Assert that TPOT uses seeds from custom dictionary as the starting population."""
-    tpot_obj = TPOTRegressor(config_dict='tests/test_config.py', generations=1, population_size=10)
+    tpot_obj = TPOTRegressor(config_dict='tests/test_config.py', population_seeds='tests/test_config.py', generations=1, population_size=10)
 
     assert isinstance(tpot_obj._pop, list)
     assert isinstance(tpot_obj._pop[0], creator.Individual)
@@ -348,23 +349,56 @@ def test_conf_dict_4():
 
 def test_conf_dict_5():
     """Assert that TPOT has a _pop attribute of the same size as the number of seeds provided."""
-    tpot_obj = TPOTRegressor(config_dict='tests/test_config.py')
+    tpot_obj = TPOTRegressor(config_dict='tests/test_config.py', population_seeds='tests/test_config.py')
     n_seeds = len(tpot_obj._read_config_file('tests/test_config.py').population_seeds)
 
     assert len(tpot_obj._pop) == n_seeds
 
 
 def test_read_config_file():
-    """Assert that _read_config_file rasie FileNotFoundError with a wrong path."""
+    """Assert that _read_config_file rasies FileNotFoundError with a wrong path."""
     tpot_obj = TPOTRegressor()
     # typo for "tests/test_config.py"
     assert_raises(ValueError, tpot_obj._read_config_file, "tests/test_confg.py")
 
 
 def test_read_config_file_2():
-    """Assert that _read_config_file rasie ValueError with wrong dictionary format"""
+    """Assert that _read_config_file rasies ValueError with wrong dictionary format"""
     tpot_obj = TPOTRegressor()
     assert_raises(ValueError, tpot_obj._read_config_file, "tests/test_config.py.bad")
+
+
+def test_read_config_file_3():
+    """Assert that _read_config_file rasies ValueError without a dictionary named 'tpot_config'."""
+    tpot_obj = TPOTRegressor()
+    assert_raises(ValueError, tpot_obj._setup_config, "tpot/config/regressor_sparse.py")
+
+
+def test_setup_pop():
+    """Assert that _setup_pop rasies ValueError without a dictionary named 'population_seeds'."""
+    tpot_obj = TPOTRegressor()
+    assert_raises(ValueError, tpot_obj._setup_pop, "tpot/config/regressor_sparse.py")
+
+
+def test_setup_pop_2():
+    """Assert that _setup_pop will not rasie ValueError with a python list"""
+    tpot_obj = TPOTRegressor()
+
+    pipeline_string = (
+        "ExtraTreesRegressor("
+        "GradientBoostingRegressor(input_matrix, GradientBoostingRegressor__alpha=0.8,"
+        "GradientBoostingRegressor__learning_rate=0.1,GradientBoostingRegressor__loss=huber,"
+        "GradientBoostingRegressor__max_depth=5, GradientBoostingRegressor__max_features=0.5,"
+        "GradientBoostingRegressor__min_samples_leaf=5, GradientBoostingRegressor__min_samples_split=5,"
+        "GradientBoostingRegressor__n_estimators=100, GradientBoostingRegressor__subsample=0.25),"
+        "ExtraTreesRegressor__bootstrap=True, ExtraTreesRegressor__max_features=0.5,"
+        "ExtraTreesRegressor__min_samples_leaf=5, ExtraTreesRegressor__min_samples_split=5, "
+        "ExtraTreesRegressor__n_estimators=100)"
+    )
+    assert tpot_obj._pop == []
+
+    tpot_obj._setup_pop([pipeline_string])
+    assert len(tpot_obj._pop) == 1
 
 
 def test_random_ind():

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -946,7 +946,7 @@ class TPOTBase(BaseEstimator):
             print('Imputing missing values in feature set')
 
         if self._fitted_imputer is None:
-            self._fitted_imputer = Imputer(strategy="median", axis=0)
+            self._fitted_imputer = Imputer(strategy="median")
             self._fitted_imputer.fit(features)
 
         return self._fitted_imputer.transform(features)

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -31,6 +31,7 @@ import os
 import re
 
 import numpy as np
+from scipy import sparse
 import deap
 from deap import base, creator, tools, gp
 from tqdm import tqdm

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -509,11 +509,11 @@ class TPOTBase(BaseEstimator):
         self._last_pipeline_write = self._start_datetime
         self._toolbox.register('evaluate', self._evaluate_individuals, features=features, target=target, sample_weight=sample_weight, groups=groups)
 
-        # assign population. self._pop maybe be non-empty if the population is
-        # seeded or a warm-start is being performed.
-        n_left_to_generate = self.population_size - len(self._pop)
-        if n_left_to_generate > 0:
-            pop = self._pop + self._toolbox.population(n=n_left_to_generate)
+        # assign population, self._pop can only be not None if warm_start is enabled
+        if self._pop:
+            pop = self._pop
+        else:
+            pop = self._toolbox.population(n=self.population_size)
 
         def pareto_eq(ind1, ind2):
             """Determine whether two individuals are equal on the Pareto front.

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -89,7 +89,7 @@ class TPOTBase(BaseEstimator):
                  mutation_rate=0.9, crossover_rate=0.1,
                  scoring=None, cv=5, subsample=1.0, n_jobs=1,
                  max_time_mins=None, max_eval_time_mins=5,
-                 random_state=None, config_dict=None, population_seeds=None,
+                 random_state=None, config_dict=None,
                  warm_start=False, periodic_checkpoint_folder=None, early_stop=None,
                  verbosity=0, disable_update_check=False):
         """Set up the genetic programming algorithm for pipeline optimization.
@@ -186,8 +186,6 @@ class TPOTBase(BaseEstimator):
             String 'TPOT sparse':
                 TPOT uses a configuration dictionary with a one-hot-encoder and the
                 operators normally included in TPOT that also support sparse matrices.
-        population_seeds: list of strings, optional (Default: None)
-            The set of pipelines used in the first generation.
         warm_start: bool, optional (default: False)
             Flag indicating whether the TPOT instance will reuse the population from
             previous calls to fit().
@@ -330,7 +328,6 @@ class TPOTBase(BaseEstimator):
 
         self._setup_pset()
         self._setup_toolbox()
-        self._setup_pop(population_seeds, config_dict)
 
 
     def _setup_config(self, config_dict):
@@ -377,20 +374,6 @@ class TPOTBase(BaseEstimator):
                 'Could not open specified TPOT operator config file: '
                 '{}'.format(config_path)
             )
-
-
-    def _setup_pop(self, population_seeds, config_path):
-        """If the population_seeds are specified, use them as the starting population."""
-        try:
-            config = self._read_config_file(config_path)
-
-            if hasattr(config, 'population_seeds'):
-                population_seeds = config.population_seeds
-        except Exception as e:
-            # Config isn't a file
-            return
-
-        self._pop = [creator.Individual.from_string(x, self._pset) for x in population_seeds]
 
 
     def _setup_pset(self):

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -187,8 +187,12 @@ class TPOTBase(BaseEstimator):
             String 'TPOT sparse':
                 TPOT uses a configuration dictionary with a one-hot-encoder and the
                 operators normally included in TPOT that also support sparse matrices.
-        population_seeds: list of strings, optional (Default: None)
-            The set of pipelines used in the first generation.
+        population_seeds: a Python list or a string, optional (Default: None)
+            Python list:
+                A list customizing a set of pipelines used in the first generation.
+            Path for configuration file:
+                A path to a configuration file for customizing a set of pipelines used in
+                the first generation.
         warm_start: bool, optional (default: False)
             Flag indicating whether the TPOT instance will reuse the population from
             previous calls to fit().
@@ -254,7 +258,8 @@ class TPOTBase(BaseEstimator):
         else:
             self.offspring_size = population_size
 
-        self._setup_config(config_dict)
+        self.config_dict_params=config_dict
+        self._setup_config(self.config_dict_params)
 
         self.operators = []
         self.arguments = []
@@ -331,7 +336,7 @@ class TPOTBase(BaseEstimator):
 
         self._setup_pset()
         self._setup_toolbox()
-        self._setup_pop(population_seeds, config_dict)
+        self._setup_pop(population_seeds)
 
 
     def _setup_config(self, config_dict):
@@ -354,7 +359,16 @@ class TPOTBase(BaseEstimator):
                 else:
                     self.config_dict = regressor_config_sparse
             else:
-                self.config_dict = self._read_config_file(config_dict).tpot_config
+                config = self._read_config_file(config_dict)
+                if hasattr(config, 'tpot_config'):
+                    self.config_dict = config.tpot_config
+                else:
+                    raise ValueError(
+                                    'Could not find "tpot_config" in configuration file {}. '
+                                    'When using a custom config file for customizing operators '
+                                    'dictionary, the file must have a python dictionary with '
+                                    'the standardized name of "tpot_config"'.format(config_dict)
+                                    )
         else:
             self.config_dict = self.default_config_dict
 
@@ -380,18 +394,24 @@ class TPOTBase(BaseEstimator):
             )
 
 
-    def _setup_pop(self, population_seeds, config_path):
+    def _setup_pop(self, population_seeds):
         """If the population_seeds are specified, use them as the starting population."""
-        try:
-            config = self._read_config_file(config_path)
+        if population_seeds:
+            if not isinstance(population_seeds, list):
+                config = self._read_config_file(population_seeds)
+                if hasattr(config, 'population_seeds'):
+                    pop_seeds = config.population_seeds
+                else:
+                    raise ValueError(
+                                    'Could not find "population_seeds" in configuration file {}. '
+                                    'When using a custom config file for customizing the seeds, '
+                                    'the file must have a list of strings with the standardized '
+                                    'name of "population_seeds"'.format(population_seeds)
+                                    )
+            else:
+                pop_seeds = population_seeds
 
-            if hasattr(config, 'population_seeds'):
-                population_seeds = config.population_seeds
-        except Exception as e:
-            # Config isn't a file
-            return
-
-        self._pop = [creator.Individual.from_string(x, self._pset) for x in population_seeds]
+            self._pop = [creator.Individual.from_string(x, self._pset) for x in pop_seeds]
 
 
     def _setup_pset(self):

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -517,12 +517,23 @@ class TPOTBase(BaseEstimator):
 
         # Resets the imputer to be fit for the new dataset
         self._fitted_imputer = None
-
-        if np.any(np.isnan(features)):
-            self._imputed = True
-            features = self._impute_values(features)
+        self._imputed = False
+        # If features is a sparse matrix, do not apply imputation
+        if sparse.issparse(features):
+            if self.config_dict_params in [None, "TPOT light", "TPOT MDR"]:
+                raise ValueError(
+                                'Not all operators in {} supports sparse matrix. '
+                                'Please use \"TPOT sparse\" for sparse matrix.'.format(self.config_dict_params)
+                                )
+            elif self.config_dict_params != "TPOT sparse":
+                print(
+                    'Warning: Since the input matrix is a sparse matrix, please makes sure all the operators in the '
+                    'customized config dictionary supports sparse matriies.'
+                    )
         else:
-            self._imputed = False
+            if np.any(np.isnan(features)):
+                self._imputed = True
+                features = self._impute_values(features)
 
         self._check_dataset(features, target)
 
@@ -956,7 +967,7 @@ class TPOTBase(BaseEstimator):
         None
         """
         try:
-            check_X_y(features, target, accept_sparse=False)
+            check_X_y(features, target, accept_sparse=True)
         except (AssertionError, ValueError):
             raise ValueError(
                 'Error: Input data is not in a valid format. Please confirm '

--- a/tpot/driver.py
+++ b/tpot/driver.py
@@ -351,18 +351,6 @@ def _get_arg_parser():
     )
 
 
-    parser.add_argument(
-        '-pseed',
-        action='store',
-        dest='POPULATION_SEEDS',
-        default=None,
-        type=str,
-        help=(
-            'Configuration file for customizing a set of pipelines used in '
-            'the first generation.'
-        )
-    )
-
 
     parser.add_argument(
         '-cf',
@@ -511,7 +499,6 @@ def tpot_driver(args):
         max_eval_time_mins=args.MAX_EVAL_MINS,
         random_state=args.RANDOM_STATE,
         config_dict=args.CONFIG_FILE,
-        population_seeds=args.POPULATION_SEEDS,
         periodic_checkpoint_folder=args.CHECKPOINT_FOLDER,
         early_stop=args.EARLY_STOP,
         verbosity=args.VERBOSITY,

--- a/tpot/driver.py
+++ b/tpot/driver.py
@@ -335,6 +335,7 @@ def _get_arg_parser():
         )
     )
 
+
     parser.add_argument(
         '-config',
         action='store',
@@ -348,6 +349,20 @@ def _get_arg_parser():
             'built-in configuration.'
         )
     )
+
+
+    parser.add_argument(
+        '-pseed',
+        action='store',
+        dest='POPULATION_SEEDS',
+        default=None,
+        type=str,
+        help=(
+            'Configuration file for customizing a set of pipelines used in '
+            'the first generation.'
+        )
+    )
+
 
     parser.add_argument(
         '-cf',
@@ -496,6 +511,7 @@ def tpot_driver(args):
         max_eval_time_mins=args.MAX_EVAL_MINS,
         random_state=args.RANDOM_STATE,
         config_dict=args.CONFIG_FILE,
+        population_seeds=args.POPULATION_SEEDS,
         periodic_checkpoint_folder=args.CHECKPOINT_FOLDER,
         early_stop=args.EARLY_STOP,
         verbosity=args.VERBOSITY,

--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -93,7 +93,7 @@ training_features, testing_features, training_target, testing_target = \\
     # Add the imputation step if it was used by TPOT
     if impute:
         pipeline_text += """
-imputer = Imputer(strategy="median", axis=0)
+imputer = Imputer(strategy="median")
 imputer.fit(training_features)
 training_features = imputer.transform(training_features)
 testing_features = imputer.transform(testing_features)


### PR DESCRIPTION
[please review the [contribution guidelines](http://rhiever.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

1. TPOT does not apply imputation on sparse matrix

2. Added checks about input type. If input matrix is a sparse matrix and `config_dict` is not `TPOT sparse` but other TPOT built-in configurations , TPOT will raise ValueError.

3. If input matrix is a sparse matrix and `config_dict` is a configuration file, TPOT will raise warning message to let user to make sure these operators in the configuration file can handle sparse matrix.

4. Add more unit tests

## Where should the reviewer start?

base.py

## What are the relevant issues?

#568 #569 

## Questions:

- Do the docs need to be updated? No
- Does this PR add new (Python) dependencies? No
