### PR TITLE
Document pipeline refit on the full training set

### DIFF
--- a/docs_sources/api.md
+++ b/docs_sources/api.md
@@ -270,7 +270,7 @@ fit(features, classes, sample_weight=None, groups=None)
 <div style="padding-left:5%" width="100%">
 Run the TPOT optimization process on the given training data.
 <br /><br />
-Uses genetic programming to optimize a machine learning pipeline that maximizes the score on the provided features and classes. Performs internal stratified k-fold cross-validaton to avoid overfitting on the provided data.
+Uses genetic programming to optimize a machine learning pipeline that maximizes the score on the provided features and target. This pipeline optimization uses internal k-fold cross-validaton to avoid overfitting on the provided data. The best pipeline is then trained on the entire set of passed samples.
 <br /><br />
 <table width="100%">
 <tr>
@@ -720,7 +720,7 @@ fit(features, target, sample_weight=None, groups=None)
 <div style="padding-left:5%" width="100%">
 Run the TPOT optimization process on the given training data.
 <br /><br />
-Uses genetic programming to optimize a machine learning pipeline that maximizes the score on the provided features and target. Performs internal k-fold cross-validaton to avoid overfitting on the provided data.
+Uses genetic programming to optimize a machine learning pipeline that maximizes the score on the provided features and target. This pipeline optimization uses internal k-fold cross-validaton to avoid overfitting on the provided data. The best pipeline is then trained on the entire set of passed samples.
 <br /><br />
 <table width="100%">
 <tr>

--- a/docs_sources/api.md
+++ b/docs_sources/api.md
@@ -270,7 +270,7 @@ fit(features, classes, sample_weight=None, groups=None)
 <div style="padding-left:5%" width="100%">
 Run the TPOT optimization process on the given training data.
 <br /><br />
-Uses genetic programming to optimize a machine learning pipeline that maximizes the score on the provided features and target. This pipeline optimization uses internal k-fold cross-validaton to avoid overfitting on the provided data. The best pipeline is then trained on the entire set of passed samples.
+Uses genetic programming to optimize a machine learning pipeline that maximizes the score on the provided features and target. This pipeline optimization procedure uses internal k-fold cross-validaton to avoid overfitting on the provided data. At the end of the pipeline optimization procedure, the best pipeline is then trained on the entire set of provided samples.
 <br /><br />
 <table width="100%">
 <tr>
@@ -720,7 +720,7 @@ fit(features, target, sample_weight=None, groups=None)
 <div style="padding-left:5%" width="100%">
 Run the TPOT optimization process on the given training data.
 <br /><br />
-Uses genetic programming to optimize a machine learning pipeline that maximizes the score on the provided features and target. This pipeline optimization uses internal k-fold cross-validaton to avoid overfitting on the provided data. The best pipeline is then trained on the entire set of passed samples.
+Uses genetic programming to optimize a machine learning pipeline that maximizes the score on the provided features and target. This pipeline optimization procedure uses internal k-fold cross-validaton to avoid overfitting on the provided data. At the end of the pipeline optimization procedure, the best pipeline is then trained on the entire set of provided samples.
 <br /><br />
 <table width="100%">
 <tr>

--- a/docs_sources/using.md
+++ b/docs_sources/using.md
@@ -75,7 +75,7 @@ pipeline_optimizer.fit(X_train, y_train)
 ```
 
 The `fit` function initializes the genetic programming algorithm to find the highest-scoring pipeline based on average k-fold cross-validation
-Then, the pipeline is trained on the entire set of passed samples, and the TPOT instance can be used as a fitted model.
+Then, the pipeline is trained on the entire set of provided samples, and the TPOT instance can be used as a fitted model.
 
 You can then proceed to evaluate the final pipeline on the testing set with the `score` function:
 

--- a/docs_sources/using.md
+++ b/docs_sources/using.md
@@ -74,8 +74,8 @@ Now TPOT is ready to optimize a pipeline for you. You can tell TPOT to optimize 
 pipeline_optimizer.fit(X_train, y_train)
 ```
 
-The `fit` function takes in a training data set and uses k-fold cross-validation when evaluating pipelines. It then
-initializes the genetic programming algoritm to find the best pipeline based on average k-fold score.
+The `fit` function initializes the genetic programming algorithm to find the highest-scoring pipeline based on average k-fold cross-validation
+Then, the pipeline is trained on the entire set of passed samples, and the TPOT instance can be used as a fitted model.
 
 You can then proceed to evaluate the final pipeline on the testing set with the `score` function:
 

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -458,7 +458,7 @@ class TPOTBase(BaseEstimator):
         Uses genetic programming to optimize a machine learning pipeline that
         maximizes score on the provided features and target. Performs internal
         k-fold cross-validaton to avoid overfitting on the provided data. The
-        best pipeline is then trained on the entire set of passed samples.
+        best pipeline is then trained on the entire set of provided samples.
 
         Parameters
         ----------

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -457,7 +457,8 @@ class TPOTBase(BaseEstimator):
 
         Uses genetic programming to optimize a machine learning pipeline that
         maximizes score on the provided features and target. Performs internal
-        k-fold cross-validaton to avoid overfitting on the training data.
+        k-fold cross-validaton to avoid overfitting on the provided data. The
+        best pipeline is then trained on the entire set of passed samples.
 
         Parameters
         ----------


### PR DESCRIPTION
## What does this PR do?
For issue #589:  Add documentation to clarify that the model generated by fit() is trained on all data, regardless of the cross-validation strategy used.


## Where should the reviewer start?
tpot/base.py  

The verbiage is identical to docs_sources/api.md

Slightly more editing was done in tpot/docs_sources/using.md

## How should this PR be tested?
Testing should not be necessary, as only documentation was edited. That said, because the phrase "testing should not be necessary" is highly correlated with impending disaster, I did run all the nosetests.

A user test could including running it by saddy001, who reported the motivating issue, and asking whether he thinks that it would have enabled him to debug the issue faster.

## Any background context you want to provide?
I decided against editing the Returns section of the doctstring, prioritizing brevity, but would certainly be open to arguments for doing so.

## What are the relevant issues?
#589 #583 

## Questions:
* Do the docs need to be updated? No further than they have been
* Does this PR add new (Python) dependencies? No