### PR TITLE
Fix a bug in mutNodeReplacement

### DIFF
--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -363,6 +363,7 @@ def mutNodeReplacement(individual, pset):
             for i, tmpnode in enumerate(individual[index + 1:], index + 1):
                 if isinstance(tmpnode, gp.Primitive) and tmpnode.ret in tmpnode.args:
                     rindex = i
+                    break
 
         # pset.primitives[node.ret] can get a list of the type of node
         # for example: if op.root is True then the node.ret is Output_DF object


### PR DESCRIPTION
## What does this PR do?

Fix a bug in point mutation operator `mutNodeReplacement` reported by @unaigarciarena in #603.

This bug would cause point mutation operator shrink pipeline if the mutation point is not the last operator or the second last operator. 

Add a unit test to test this issue.

## Where should the reviewer start?

Line 366 in `deap_gp.py`


## What are the relevant issues?

#603 



## Questions:

- Do the docs need to be updated? No
- Does this PR add new (Python) dependencies? No
