### PR TITLE
Update installation guide of pywin32

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,8 +19,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy nose cython py-xgboost pandas
-  - conda install scikit-learn=0.19.0
+  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn nose cython py-xgboost pandas mkl
   - activate test-environment
   - pip install deap tqdm update_checker pypiwin32 stopit
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,8 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn nose cython py-xgboost pandas
+  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy nose cython py-xgboost pandas
+  - conda install scikit-learn=0.19.0
   - activate test-environment
   - pip install deap tqdm update_checker pypiwin32 stopit
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn nose cython py-xgboost pandas mkl
+  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn nose cython pandas
   - activate test-environment
   - pip install deap tqdm update_checker pypiwin32 stopit
 

--- a/docs_sources/installing.md
+++ b/docs_sources/installing.md
@@ -33,9 +33,9 @@ pip install deap update_checker tqdm stopit
 **For the Windows users**, the pywin32 module is required if Python is NOT installed via the [Anaconda Python distribution](https://www.continuum.io/downloads) and can be installed with `pip` for Python verion <=3.3 or `conda` (e.g. miniconda) for any Python version:
 
 ```Shell
-# Python version <=3.3
+# For Python version <=3.3
 pip install pywin32
-# Any python version
+# For Any python version
 conda install pywin32
 ```
 

--- a/docs_sources/installing.md
+++ b/docs_sources/installing.md
@@ -30,10 +30,10 @@ DEAP, update_checker, tqdm and stopit can be installed with `pip` via the comman
 pip install deap update_checker tqdm stopit
 ```
 
-**For the Windows users**, the pywin32 module is required if Python is NOT installed via the [Anaconda Python distribution](https://www.continuum.io/downloads) and can be installed with `pip`:
+**For the Windows users**, the pywin32 module is required and can be installed with `conda`:
 
 ```Shell
-pip install pywin32
+conda install pywin32
 ```
 
 **Optionally**, you can install [XGBoost](https://github.com/dmlc/xgboost) if you would like TPOT to use the eXtreme Gradient Boosting models. XGBoost is entirely optional, and TPOT will still function normally without XGBoost if you do not have it installed.

--- a/docs_sources/installing.md
+++ b/docs_sources/installing.md
@@ -30,9 +30,12 @@ DEAP, update_checker, tqdm and stopit can be installed with `pip` via the comman
 pip install deap update_checker tqdm stopit
 ```
 
-**For the Windows users**, the pywin32 module is required and can be installed with `conda`:
+**For the Windows users**, the pywin32 module is required if Python is NOT installed via the [Anaconda Python distribution](https://www.continuum.io/downloads) and can be installed with `pip` for Python verion <=3.3 or `conda` (e.g. miniconda) for any Python version:
 
 ```Shell
+# Python version <=3.3
+pip install pywin32
+# Any python version
 conda install pywin32
 ```
 


### PR DESCRIPTION
Just update installation guide for pywin32 and require windows users to install pywin32 from conda instead of pypi.

Related issue #605 