### PR TITLE
Add docstring ARGTypeClassFactory and fix ArgBaseClass parameter in TPOTOperatorClassFactory

### DIFF
--- a/tpot/operator_utils.py
+++ b/tpot/operator_utils.py
@@ -105,7 +105,23 @@ def set_sample_weight(pipeline_steps, sample_weight=None):
 
 
 def ARGTypeClassFactory(classname, prange, BaseClass=ARGType):
-    """Dynamically create parameter type class."""
+    """Dynamically create parameter type class.
+
+    Parameters
+    ----------
+    classname: string
+        parameter name in a operator
+    prange: list
+        list of values for the parameter in a operator
+    BaseClass: Class
+        inherited BaseClass for parameter
+
+    Returns
+    -------
+    Class
+        parameter class
+
+    """
     return type(classname, (BaseClass,), {'values': prange})
 
 
@@ -123,7 +139,9 @@ def TPOTOperatorClassFactory(opsourse, opdict, BaseClass=Operator, ArgBaseClass=
     classification: bool
         True if it can be used in TPOTClassifier
     BaseClass: Class
-        inherited BaseClass
+        inherited BaseClass for operator
+    ArgBaseClass: Class
+        inherited BaseClass for parameter
 
     Returns
     -------
@@ -166,7 +184,7 @@ def TPOTOperatorClassFactory(opsourse, opdict, BaseClass=Operator, ArgBaseClass=
             prange = opdict[pname]
             if not isinstance(prange, dict):
                 classname = '{}__{}'.format(op_str, pname)
-                arg_types.append(ARGTypeClassFactory(classname, prange))
+                arg_types.append(ARGTypeClassFactory(classname, prange, ArgBaseClass))
             else:
                 for dkey, dval in prange.items():
                     dep_import_str, dep_op_str, dep_op_obj = source_decode(dkey)
@@ -179,7 +197,7 @@ def TPOTOperatorClassFactory(opsourse, opdict, BaseClass=Operator, ArgBaseClass=
                         for dpname in sorted(dval.keys()):
                             dprange = dval[dpname]
                             classname = '{}__{}__{}'.format(op_str, dep_op_str, dpname)
-                            arg_types.append(ARGTypeClassFactory(classname, dprange))
+                            arg_types.append(ARGTypeClassFactory(classname, dprange, ArgBaseClass))
         class_profile['arg_types'] = tuple(arg_types)
         class_profile['import_hash'] = import_hash
         class_profile['dep_op_list'] = dep_op_list


### PR DESCRIPTION
## What does this PR do?

1. add docstring `ARGTypeClassFactory` function 
2. fix `ArgBaseClass` parameter in `TPOTOperatorClassFactory`: The parameter is not used in `ARGTypeClassFactory` function within  `TPOTOperatorClassFactory`, even though it does not cause issues in TPOT since `ARGTypeClassFactory` has default value in its third argument. I posted this fix just for clean codes.


