### PR TITLE
Fix a bug in the old scoring API when introducing the new API in TPOT 0.9.1

### DIFF
--- a/tests/export_tests.py
+++ b/tests/export_tests.py
@@ -76,7 +76,6 @@ exported_pipeline = make_pipeline(
 exported_pipeline.fit(training_features, training_target)
 results = exported_pipeline.predict(testing_features)
 """
-    print(export_pipeline(pipeline, tpot_obj.operators, tpot_obj._pset))
     assert expected_code == export_pipeline(pipeline, tpot_obj.operators, tpot_obj._pset)
 
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -144,11 +144,11 @@ def test_init_default_scoring():
 
 def test_init_default_scoring_2():
     """Assert that TPOT intitializes with a valid customized metric function."""
-    with warnings.catch_warnings(record=True) as w:
-        tpot_obj = TPOTClassifier(scoring=balanced_accuracy)
-    assert len(w) == 1
-    assert issubclass(w[-1].category, DeprecationWarning)
-    assert "This scoring type was deprecated" in str(w[-1].message)
+    #with warnings.catch_warnings(record=True) as w:
+    tpot_obj = TPOTClassifier(scoring=balanced_accuracy)
+    #assert len(w) == 1 # deap 1.2.2 warning message made this unit test failed
+    #assert issubclass(w[-1].category, DeprecationWarning) # deap 1.2.2 warning message made this unit test failed
+    #assert "This scoring type was deprecated" in str(w[-1].message) # deap 1.2.2 warning message made this unit test failed
     assert tpot_obj.scoring_function == 'balanced_accuracy'
 
 
@@ -156,7 +156,7 @@ def test_init_default_scoring_3():
     """Assert that TPOT intitializes with a valid _BaseScorer."""
     with warnings.catch_warnings(record=True) as w:
         tpot_obj = TPOTClassifier(scoring=make_scorer(balanced_accuracy))
-    assert len(w) == 0
+    #assert len(w) == 0 # deap 1.2.2 warning message made this unit test failed
     assert tpot_obj.scoring_function == 'balanced_accuracy'
 
 
@@ -167,7 +167,7 @@ def test_init_default_scoring_4():
 
     with warnings.catch_warnings(record=True) as w:
         tpot_obj = TPOTClassifier(scoring=my_scorer)
-    assert len(w) == 0
+    #assert len(w) == 0 # deap 1.2.2 warning message made this unit test failed
     assert tpot_obj.scoring_function == 'my_scorer'
 
 
@@ -1757,7 +1757,8 @@ def test_mutNodeReplacement():
         if new_prims_list == old_prims_list:  # Terminal mutated
             assert new_ret_type_list == old_ret_type_list
         else:  # Primitive mutated
-            diff_prims = list(set(new_prims_list).symmetric_difference(old_prims_list))
+            diff_prims = [x for x in new_prims_list if x not in old_prims_list]
+            diff_prims += [x for x in old_prims_list if x not in new_prims_list]
             if len(diff_prims) > 1: # Sometimes mutation randomly replaces an operator that already in the pipelines
                 assert diff_prims[0].ret == diff_prims[1].ret
         assert mut_ind[0][0].ret == Output_Array
@@ -1795,7 +1796,8 @@ def test_mutNodeReplacement_2():
                 if isinstance(node, gp.Primitive):
                     Primitive_Count += 1
             assert Primitive_Count == 4
-            diff_prims = list(set(new_prims_list).symmetric_difference(old_prims_list))
+            diff_prims = [x for x in new_prims_list if x not in old_prims_list]
+            diff_prims += [x for x in old_prims_list if x not in new_prims_list]
             if len(diff_prims) > 1: # Sometimes mutation randomly replaces an operator that already in the pipelines
                 assert diff_prims[0].ret == diff_prims[1].ret
         assert mut_ind[0][0].ret == Output_Array

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -144,8 +144,8 @@ def test_init_default_scoring():
 
 def test_init_default_scoring_2():
     """Assert that TPOT intitializes with a valid customized metric function."""
-    #with warnings.catch_warnings(record=True) as w:
-    tpot_obj = TPOTClassifier(scoring=balanced_accuracy)
+    with warnings.catch_warnings(record=True) as w:
+        tpot_obj = TPOTClassifier(scoring=balanced_accuracy)
     assert len(w) == 1 # deap 1.2.2 warning message made this unit test failed
     assert issubclass(w[-1].category, DeprecationWarning) # deap 1.2.2 warning message made this unit test failed
     assert "This scoring type was deprecated" in str(w[-1].message) # deap 1.2.2 warning message made this unit test failed

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -146,9 +146,9 @@ def test_init_default_scoring_2():
     """Assert that TPOT intitializes with a valid customized metric function."""
     #with warnings.catch_warnings(record=True) as w:
     tpot_obj = TPOTClassifier(scoring=balanced_accuracy)
-    #assert len(w) == 1 # deap 1.2.2 warning message made this unit test failed
-    #assert issubclass(w[-1].category, DeprecationWarning) # deap 1.2.2 warning message made this unit test failed
-    #assert "This scoring type was deprecated" in str(w[-1].message) # deap 1.2.2 warning message made this unit test failed
+    assert len(w) == 1 # deap 1.2.2 warning message made this unit test failed
+    assert issubclass(w[-1].category, DeprecationWarning) # deap 1.2.2 warning message made this unit test failed
+    assert "This scoring type was deprecated" in str(w[-1].message) # deap 1.2.2 warning message made this unit test failed
     assert tpot_obj.scoring_function == 'balanced_accuracy'
 
 
@@ -156,7 +156,7 @@ def test_init_default_scoring_3():
     """Assert that TPOT intitializes with a valid _BaseScorer."""
     with warnings.catch_warnings(record=True) as w:
         tpot_obj = TPOTClassifier(scoring=make_scorer(balanced_accuracy))
-    #assert len(w) == 0 # deap 1.2.2 warning message made this unit test failed
+    assert len(w) == 0 # deap 1.2.2 warning message made this unit test failed
     assert tpot_obj.scoring_function == 'balanced_accuracy'
 
 
@@ -167,7 +167,7 @@ def test_init_default_scoring_4():
 
     with warnings.catch_warnings(record=True) as w:
         tpot_obj = TPOTClassifier(scoring=my_scorer)
-    #assert len(w) == 0 # deap 1.2.2 warning message made this unit test failed
+    assert len(w) == 0 # deap 1.2.2 warning message made this unit test failed
     assert tpot_obj.scoring_function == 'my_scorer'
 
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -170,6 +170,7 @@ def test_init_default_scoring_4():
     assert len(w) == 0
     assert tpot_obj.scoring_function == 'my_scorer'
 
+
 def test_init_default_scoring_5():
     """Assert that TPOT intitializes with a valid sklearn metric function roc_auc_score."""
     with warnings.catch_warnings(record=True) as w:
@@ -178,6 +179,19 @@ def test_init_default_scoring_5():
     assert issubclass(w[-1].category, DeprecationWarning)
     assert "This scoring type was deprecated" in str(w[-1].message)
     assert tpot_obj.scoring_function == 'roc_auc_score'
+
+
+def test_init_default_scoring_6():
+    """Assert that TPOT intitializes with a valid customized metric function in __main__"""
+    def my_scorer(y_true, y_pred):
+        return roc_auc_score(y_true, y_pred)
+    with warnings.catch_warnings(record=True) as w:
+        tpot_obj = TPOTClassifier(scoring=my_scorer)
+    assert len(w) == 1
+    assert issubclass(w[-1].category, DeprecationWarning)
+    assert "This scoring type was deprecated" in str(w[-1].message)
+    print(tpot_obj.scoring_function)
+    assert tpot_obj.scoring_function == 'my_scorer'
 
 
 def test_invalid_score_warning():

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -146,9 +146,9 @@ def test_init_default_scoring_2():
     """Assert that TPOT intitializes with a valid customized metric function."""
     with warnings.catch_warnings(record=True) as w:
         tpot_obj = TPOTClassifier(scoring=balanced_accuracy)
-    assert len(w) == 1 # deap 1.2.2 warning message made this unit test failed
-    assert issubclass(w[-1].category, DeprecationWarning) # deap 1.2.2 warning message made this unit test failed
-    assert "This scoring type was deprecated" in str(w[-1].message) # deap 1.2.2 warning message made this unit test failed
+    assert len(w) == 1
+    assert issubclass(w[-1].category, DeprecationWarning)
+    assert "This scoring type was deprecated" in str(w[-1].message)
     assert tpot_obj.scoring_function == 'balanced_accuracy'
 
 
@@ -156,7 +156,7 @@ def test_init_default_scoring_3():
     """Assert that TPOT intitializes with a valid _BaseScorer."""
     with warnings.catch_warnings(record=True) as w:
         tpot_obj = TPOTClassifier(scoring=make_scorer(balanced_accuracy))
-    assert len(w) == 0 # deap 1.2.2 warning message made this unit test failed
+    assert len(w) == 0
     assert tpot_obj.scoring_function == 'balanced_accuracy'
 
 
@@ -167,7 +167,7 @@ def test_init_default_scoring_4():
 
     with warnings.catch_warnings(record=True) as w:
         tpot_obj = TPOTClassifier(scoring=my_scorer)
-    assert len(w) == 0 # deap 1.2.2 warning message made this unit test failed
+    assert len(w) == 0
     assert tpot_obj.scoring_function == 'my_scorer'
 
 

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -56,7 +56,7 @@ from shutil import rmtree
 from sklearn.datasets import load_digits, load_boston
 from sklearn.model_selection import train_test_split, cross_val_score, GroupKFold
 from sklearn.externals.joblib import Memory
-from sklearn.metrics import make_scorer
+from sklearn.metrics import make_scorer, roc_auc_score
 from deap import creator, gp
 from deap.tools import ParetoFront
 from nose.tools import assert_raises, assert_not_equal, assert_greater_equal, assert_equal, assert_in
@@ -169,6 +169,15 @@ def test_init_default_scoring_4():
         tpot_obj = TPOTClassifier(scoring=my_scorer)
     assert len(w) == 0
     assert tpot_obj.scoring_function == 'my_scorer'
+
+def test_init_default_scoring_5():
+    """Assert that TPOT intitializes with a valid sklearn metric function roc_auc_score."""
+    with warnings.catch_warnings(record=True) as w:
+        tpot_obj = TPOTClassifier(scoring=roc_auc_score)
+    assert len(w) == 1
+    assert issubclass(w[-1].category, DeprecationWarning)
+    assert "This scoring type was deprecated" in str(w[-1].message)
+    assert tpot_obj.scoring_function == 'roc_auc_score'
 
 
 def test_invalid_score_warning():

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -359,7 +359,10 @@ class TPOTBase(BaseEstimator):
                 # Heuristic to ensure user has not passed a metric
                 module = getattr(scoring, '__module__', None)
                 if sys.version_info[0] < 3:
-                    args_list = inspect.getargspec(scoring)[0]
+                    if not inspect.isclass(scoring)
+                        args_list = inspect.getargspec(scoring)[0]
+                    else:
+                        args_list = ['NA', 'NA']
                 else:
                     args_list = inspect.getfullargspec(scoring)[0]
                 if args_list == ["y_true", "y_pred"] or (hasattr(module, 'startswith') and \

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -359,7 +359,7 @@ class TPOTBase(BaseEstimator):
                 # Heuristic to ensure user has not passed a metric
                 module = getattr(scoring, '__module__', None)
                 if sys.version_info[0] < 3:
-                    if not inspect.isclass(scoring)
+                    if not inspect.isclass(scoring):
                         args_list = inspect.getargspec(scoring)[0]
                     else:
                         args_list = ['NA', 'NA']

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -358,10 +358,14 @@ class TPOTBase(BaseEstimator):
             elif callable(scoring):
                 # Heuristic to ensure user has not passed a metric
                 module = getattr(scoring, '__module__', None)
-                if hasattr(module, 'startswith') and \
+                if sys.version_info[0] < 3:
+                    args_list = inspect.getargspec(scoring)[0]
+                else:
+                    args_list = inspect.getfullargspec(scoring)[0]
+                if args_list == ["y_true", "y_pred"] or (hasattr(module, 'startswith') and \
                     (module.startswith('sklearn.metrics.') or module.startswith('tpot.metrics')) and \
                     not module.startswith('sklearn.metrics.scorer') and \
-                    not module.startswith('sklearn.metrics.tests.'):
+                    not module.startswith('sklearn.metrics.tests.')):
                     scoring_name = scoring.__name__
                     greater_is_better = 'loss' not in scoring_name and 'error' not in scoring_name
                     SCORERS[scoring_name] = make_scorer(scoring, greater_is_better=greater_is_better)
@@ -946,7 +950,7 @@ class TPOTBase(BaseEstimator):
             if e.errno == errno.EEXIST and os.path.isdir(self.periodic_checkpoint_folder):
                 pass # Folder already exists. User probably created it.
             else:
-                raise ValueError('Failed creating the periodic_checkpoint_folder:\n{}'.format(e))     
+                raise ValueError('Failed creating the periodic_checkpoint_folder:\n{}'.format(e))
 
     def export(self, output_file_name, skip_if_repeated=False):
         """Export the optimized pipeline as Python code.

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -359,10 +359,10 @@ class TPOTBase(BaseEstimator):
                 # Heuristic to ensure user has not passed a metric
                 module = getattr(scoring, '__module__', None)
                 if sys.version_info[0] < 3:
-                    if not inspect.isclass(scoring):
+                    if inspect.isfunction(scoring):
                         args_list = inspect.getargspec(scoring)[0]
                     else:
-                        args_list = ['NA', 'NA']
+                        args_list = inspect.getargspec(scoring.__call__)[0]
                 else:
                     args_list = inspect.getfullargspec(scoring)[0]
                 if args_list == ["y_true", "y_pred"] or (hasattr(module, 'startswith') and \

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -481,8 +481,10 @@ class TPOTBase(BaseEstimator):
                 self._pset.addTerminal(val, _type, name=terminal_name)
 
     def _setup_toolbox(self):
-        creator.create('FitnessMulti', base.Fitness, weights=(-1.0, 1.0))
-        creator.create('Individual', gp.PrimitiveTree, fitness=creator.FitnessMulti, statistics=dict)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            creator.create('FitnessMulti', base.Fitness, weights=(-1.0, 1.0))
+            creator.create('Individual', gp.PrimitiveTree, fitness=creator.FitnessMulti, statistics=dict)
 
         self._toolbox = base.Toolbox()
         self._toolbox.register('expr', self._gen_grow_safe, pset=self._pset, min_=1, max_=3)
@@ -946,7 +948,7 @@ class TPOTBase(BaseEstimator):
             if e.errno == errno.EEXIST and os.path.isdir(self.periodic_checkpoint_folder):
                 pass # Folder already exists. User probably created it.
             else:
-                raise ValueError('Failed creating the periodic_checkpoint_folder:\n{}'.format(e))     
+                raise ValueError('Failed creating the periodic_checkpoint_folder:\n{}'.format(e))
 
     def export(self, output_file_name, skip_if_repeated=False):
         """Export the optimized pipeline as Python code.


### PR DESCRIPTION
1. Fix a bug in the new scoring API in TPOT 0.9.1, which cause TPOT cannot recognize the scoring function in the old scoring API (which will be removed in version 0.11).

2. Add two unit tests for the related issue #625 

## Questions:

- Do the docs need to be updated? No
- Does this PR add new (Python) dependencies? No
