### PR TITLE
Fix "stopit" and "pandas" required version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ scikit-learn==0.18.1
 scipy==0.19.0
 tqdm==4.11.2
 update-checker==0.16
-stopit=1.1.1
-pandas=0.20.2
+stopit==1.1.1
+pandas==0.20.2


### PR DESCRIPTION
Before this commit, executing  `pip install -r requirements.txt` cause an error due invalid version syntax

## What does this PR do?
Fix the requirements file syntax

## Where should the reviewer start?
Looking that the current version executing `pip install -r requirements.txt` does not work


## How should this PR be tested?
`pip install -r requirements.txt` should work correctly and install the dependencies


## What are the relevant issues?
If someone wants to install the TPOP dependencies, it won't work

## Questions:

- Do the docs need to be updated?
No
- Does this PR add new (Python) dependencies?
No
