### PR TITLE
max_eval_time can be any postive float instead of integer

### DIFF
--- a/docs_sources/api.md
+++ b/docs_sources/api.md
@@ -116,7 +116,7 @@ How many minutes TPOT has to optimize the pipeline.
 If not None, this setting will override the <em>generations</em> parameter and allow TPOT to run until <em>max_time_mins</em> minutes elapse.
 </blockquote>
 
-<strong>max_eval_time_mins</strong>: integer, optional (default=5)
+<strong>max_eval_time_mins</strong>: float, optional (default=5)
 <blockquote>
 How many minutes TPOT has to evaluate a single pipeline.
 <br /><br />
@@ -588,7 +588,7 @@ How many minutes TPOT has to optimize the pipeline.
 If not None, this setting will override the <em>generations</em> parameter and allow TPOT to run until <em>max_time_mins</em> minutes elapse.
 </blockquote>
 
-<strong>max_eval_time_mins</strong>: integer, optional (default=5)
+<strong>max_eval_time_mins</strong>: float, optional (default=5)
 <blockquote>
 How many minutes TPOT has to evaluate a single pipeline.
 <br /><br />

--- a/docs_sources/using.md
+++ b/docs_sources/using.md
@@ -253,7 +253,7 @@ If provided, this setting will override the "generations" parameter and allow TP
 <tr>
 <td>-maxeval</td>
 <td>MAX_EVAL_MINS</td>
-<td>Any positive integer</td>
+<td>Any positive float</td>
 <td>How many minutes TPOT has to evaluate a single pipeline.
 <br /><br />
 Setting this parameter to higher values will allow TPOT to consider more complex pipelines but will also allow TPOT to run longer.</td>

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -174,7 +174,7 @@ class TPOTBase(BaseEstimator):
             How many minutes TPOT has to optimize the pipeline.
             If provided, this setting will override the "generations" parameter and allow
             TPOT to run until it runs out of time.
-        max_eval_time_mins: int, optional (default: 5)
+        max_eval_time_mins: float, optional (default: 5)
             How many minutes TPOT has to optimize a single pipeline.
             Setting this parameter to higher values will allow TPOT to explore more
             complex pipelines, but will also allow TPOT to run longer.


### PR DESCRIPTION
Update docs for max_eval_time.

Related to #697 