### PR TITLE
Add a rescore parameter

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -100,7 +100,7 @@ class TPOTBase(BaseEstimator):
 
     def __init__(self, generations=100, population_size=100, offspring_size=None,
                  mutation_rate=0.9, crossover_rate=0.1,
-                 scoring=None, cv=5, subsample=1.0, n_jobs=1,
+                 scoring=None, cv=5, subsample=1.0, n_jobs=1, rescore=False,
                  max_time_mins=None, max_eval_time_mins=5,
                  random_state=None, config_dict=None,
                  warm_start=False, memory=None,
@@ -170,6 +170,10 @@ class TPOTBase(BaseEstimator):
             Number of CPUs for evaluating pipelines in parallel during the TPOT
             optimization process. Assigning this to -1 will use as many cores as available
             on the computer.
+        rescore: bool, optional (default: False)
+            Whether surviving pipelines should be re-evaluated every generation. This is only
+            necessary if your training data or scoring context changes from generation to
+            generation.
         max_time_mins: int, optional (default: None)
             How many minutes TPOT has to optimize the pipeline.
             If provided, this setting will override the "generations" parameter and allow
@@ -341,6 +345,8 @@ class TPOTBase(BaseEstimator):
             self.n_jobs = cpu_count()
         else:
             self.n_jobs = n_jobs
+
+        self.rescore = rescore
 
         self._setup_pset()
         self._setup_toolbox()
@@ -615,7 +621,8 @@ class TPOTBase(BaseEstimator):
                     pbar=self._pbar,
                     halloffame=self._pareto_front,
                     verbose=self.verbosity,
-                    per_generation_function=self._check_periodic_pipeline
+                    per_generation_function=self._check_periodic_pipeline,
+                    rescore=self.rescore
                 )
 
             # store population for the next call

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -172,7 +172,7 @@ def initialize_stats_dict(individual):
 
 
 def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
-                   stats=None, halloffame=None, verbose=0, per_generation_function=None):
+                   stats=None, halloffame=None, verbose=0, per_generation_function=None, rescore=False):
     """This is the :math:`(\mu + \lambda)` evolutionary algorithm.
     :param population: A list of individuals.
     :param toolbox: A :class:`~deap.base.Toolbox` that contains the evolution
@@ -190,6 +190,7 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
     :param verbose: Whether or not to log the statistics.
     :param per_generation_function: if supplied, call this function before each generation
                             used by tpot to save best pipeline before each new generation
+    :param rescore: Whether surviving pipelines should be re-evaluated every generation
     :returns: The final population
     :returns: A class:`~deap.tools.Logbook` with the statistics of the
               evolution.
@@ -225,7 +226,7 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
         initialize_stats_dict(ind)
 
     # Evaluate the individuals with an invalid fitness
-    invalid_ind = [ind for ind in population if not ind.fitness.valid]
+    invalid_ind = [ind for ind in population if rescore or not ind.fitness.valid]
 
     fitnesses = toolbox.evaluate(invalid_ind)
     for ind, fit in zip(invalid_ind, fitnesses):
@@ -253,7 +254,7 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
                 ind.statistics['generation'] = gen
 
         # Evaluate the individuals with an invalid fitness
-        invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
+        invalid_ind = [ind for ind in offspring if rescore or not ind.fitness.valid]
 
         # update pbar for valid individuals (with fitness values)
         if not pbar.disable:

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -253,8 +253,11 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
             if ind.statistics['generation'] == 'INVALID':
                 ind.statistics['generation'] = gen
 
-        # Evaluate the individuals with an invalid fitness
-        invalid_ind = [ind for ind in offspring if rescore or not ind.fitness.valid]
+        # Evaluate the individuals with an invalid or outdated fitness
+        if rescore:
+            invalid_ind = population + offspring
+        else:
+            invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
 
         # update pbar for valid individuals (with fitness values)
         if not pbar.disable:


### PR DESCRIPTION
If the training data or scoring context changes from generation to generation, fitness metrics can't be reused for surviving pipelines. If `rescore` is set, all individuals are evaluated every generation.