### PR TITLE
Add imputation to predict proba

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -860,6 +860,12 @@ class TPOTBase(BaseEstimator):
         else:
             if not (hasattr(self.fitted_pipeline_, 'predict_proba')):
                 raise RuntimeError('The fitted pipeline does not have the predict_proba() function.')
+
+            features = features.astype(np.float64)
+
+            if np.any(np.isnan(features)):
+                features = self._impute_values(features)
+
             return self.fitted_pipeline_.predict_proba(features.astype(np.float64))
 
     def set_params(self, **params):


### PR DESCRIPTION
## What does this PR do?
Updates predict proba to impute values to prevent it from breaking from nan inputs.

## Where should the reviewer start?
tpot/base.py
  --> def predict_proba(self, features):
         ....

## How should this PR be tested?
Try using a test input with nans in predict_proba

## Any background context you want to provide?
Predict proba was breaking before this change.

## What are the relevant issues?
None

## Screenshots (if appropriate)
N/A

## Questions:
- Do the docs need to be updated?
No
- Does this PR add new (Python) dependencies?
No