### PR TITLE
[WIP] Use dask.delayed within fit

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn nose cython pandas
   - activate test-environment
-  - pip install deap tqdm update_checker pypiwin32 stopit dask[delayed] dask-ml
+  - pip install deap tqdm update_checker pypiwin32 stopit dask[delayed] git+https://github.com/dask/dask-ml
 
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn nose cython pandas
   - activate test-environment
-  - pip install deap tqdm update_checker pypiwin32 stopit dask[delayed]
+  - pip install deap tqdm update_checker pypiwin32 stopit dask[delayed] dask-ml
 
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn nose cython pandas
   - activate test-environment
-  - pip install deap tqdm update_checker pypiwin32 stopit
+  - pip install deap tqdm update_checker pypiwin32 stopit dask[delayed]
 
 
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 virtualenv:
   system_site_packages: true
 env:
+  global:
+    PYTHONHASHSEED: 0
   matrix:
     # let's start simple:
     - PYTHON_VERSION="2.7" LATEST="true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 virtualenv:
   system_site_packages: true
 env:
-  global:
-    PYTHONHASHSEED: 0
   matrix:
     # let's start simple:
     - PYTHON_VERSION="2.7" LATEST="true"

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -55,7 +55,7 @@ pip install tqdm
 pip install stopit
 pip install xgboost
 pip install dask[delayed]
-pip install git+https://github.com/dask/dask-ml
+pip install git+https://github.com/dask/dask-ml  # TODO: Change to >=0.9 when released
 
 if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -54,7 +54,7 @@ pip install update_checker
 pip install tqdm
 pip install stopit
 pip install xgboost
-pip install dask[delayed]
+pip install dask[delayed] dask-ml
 
 if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -54,7 +54,8 @@ pip install update_checker
 pip install tqdm
 pip install stopit
 pip install xgboost
-pip install dask[delayed] dask-ml
+pip install dask[delayed]
+pip install git+https://github.com/dask/dask-ml
 
 if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -54,6 +54,7 @@ pip install update_checker
 pip install tqdm
 pip install stopit
 pip install xgboost
+pip install dask[delayed]
 
 if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ This project is hosted at https://github.com/EpistasisLab/tpot
         'mdr': ['scikit-mdr>=0.4.4'],
         'dask': ['dask>=0.18.2',
                  'distributed>=1.22.1',
-                 'dask-ml>=0.7.0'],
+                 'dask-ml>=0.8.0'],
     },
     classifiers=[
         'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,10 @@ This project is hosted at https://github.com/EpistasisLab/tpot
     extras_require={
         'xgboost': ['xgboost==0.6a2'],
         'skrebate': ['skrebate>=0.3.4'],
-        'mdr': ['scikit-mdr>=0.4.4']
+        'mdr': ['scikit-mdr>=0.4.4'],
+        'dask': ['dask>=0.18.2',
+                 'distributed>=1.22.1',
+                 'dask-ml>=0.7.0'],
     },
     classifiers=[
         'Intended Audience :: Science/Research',

--- a/tests/driver_tests.py
+++ b/tests/driver_tests.py
@@ -25,7 +25,6 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess
 import sys
-import warnings
 from os import remove, path
 from contextlib import contextmanager
 from distutils.version import LooseVersion
@@ -34,6 +33,7 @@ try:
 except ImportError:
     from io import StringIO
 
+import nose
 import numpy as np
 import pandas as pd
 import sklearn
@@ -175,8 +175,9 @@ def test_driver_5():
     """Assert that the tpot_driver() in TPOT driver outputs normal result with exported python file and verbosity = 0."""
 
     # Catch FutureWarning https://github.com/scikit-learn/scikit-learn/issues/11785
-    handle_warning = (np.__version__ >= LooseVersion("1.15.0") and
-                      sklearn.__version__ <= LooseVersion("0.20.0"))
+    if (np.__version__ >= LooseVersion("1.15.0") and
+            sklearn.__version__ <= LooseVersion("0.20.0")):
+        raise nose.SkipTest("Warning raised by scikit-learn")
 
     args_list = [
                 'tests/tests.csv',
@@ -192,12 +193,7 @@ def test_driver_5():
                 ]
     args = _get_arg_parser().parse_args(args_list)
     with captured_output() as (out, err):
-        with warnings.catch_warnings():
-            if handle_warning:
-                warnings.filterwarnings("ignore",
-                                        category=FutureWarning,
-                                        module="numpy", append=True)
-            tpot_driver(args)
+        tpot_driver(args)
     ret_stdout = out.getvalue()
 
     assert ret_stdout == ""

--- a/tests/test_dask_based.py
+++ b/tests/test_dask_based.py
@@ -11,7 +11,6 @@ from tpot import TPOTClassifier
 
 try:
     import dask
-    import dask_ml.utils
 except ImportError:
     raise nose.SkipTest()
 
@@ -27,7 +26,7 @@ class TestDaskMatches(unittest.TestCase):
                 population_size=5,
                 cv=3,
                 random_state=0,
-                n_jobs=-1,
+                n_jobs=n_jobs,
                 use_dask=False,
             )
             b = TPOTClassifier(
@@ -35,13 +34,14 @@ class TestDaskMatches(unittest.TestCase):
                 population_size=5,
                 cv=3,
                 random_state=0,
-                n_jobs=-1,
+                n_jobs=n_jobs,
                 use_dask=True,
             )
             b.fit(X, y)
             a.fit(X, y)
-            self.assertEqual(a.evaluated_individuals_,
-                             b.evaluated_individuals_)
+
+            self.assertEqual(a.score(X, y), b.score(X, y))
             self.assertEqual(a.pareto_front_fitted_pipelines_.keys(),
                              b.pareto_front_fitted_pipelines_.keys())
-            self.assertEqual(a.score(X, y), b.score(X, y))
+            self.assertEqual(a.evaluated_individuals_,
+                             b.evaluated_individuals_)

--- a/tests/test_dask_based.py
+++ b/tests/test_dask_based.py
@@ -16,23 +16,30 @@ except ImportError:
     raise nose.SkipTest()
 
 
-
 class TestDaskMatches(unittest.TestCase):
     def test_dask_matches(self):
-        a = TPOTClassifier(
-            generations=2,
-            population_size=5,
-            cv=3,
-            random_state=0,
-            use_dask=False,
-        )
-        b = TPOTClassifier(
-            generations=2,
-            population_size=5,
-            cv=3,
-            random_state=0,
-            use_dask=True,
-        )
-        X, y = make_classification(random_state=0)
-        a.fit(X, y)
-        b.fit(X, y)
+        for n_jobs in [1, -1]:
+            X, y = make_classification(random_state=0)
+            a = TPOTClassifier(
+                generations=2,
+                population_size=5,
+                cv=3,
+                random_state=0,
+                n_jobs=-1,
+                use_dask=False,
+            )
+            b = TPOTClassifier(
+                generations=2,
+                population_size=5,
+                cv=3,
+                random_state=0,
+                n_jobs=-1,
+                use_dask=True,
+            )
+            b.fit(X, y)
+            a.fit(X, y)
+            self.assertEqual(a.evaluated_individuals_,
+                             b.evaluated_individuals_)
+            self.assertEqual(a.pareto_front_fitted_pipelines_.keys(),
+                             b.pareto_front_fitted_pipelines_.keys())
+            self.assertEqual(a.score(X, y), b.score(X, y))

--- a/tests/test_dask_based.py
+++ b/tests/test_dask_based.py
@@ -46,3 +46,33 @@ class TestDaskMatches(unittest.TestCase):
                              b.pareto_front_fitted_pipelines_.keys())
             self.assertEqual(a.evaluated_individuals_,
                              b.evaluated_individuals_)
+
+    def test_handles_errors(self):
+        X, y = make_classification(n_samples=5)
+
+        tpot_config = {
+            'sklearn.neighbors.KNeighborsClassifier': {
+                'n_neighbors': [1, 100],
+            }
+        }
+
+        a = TPOTClassifier(
+            generations=2,
+            population_size=5,
+            cv=3,
+            random_state=0,
+            n_jobs=-1,
+            config_dict=tpot_config,
+            use_dask=False,
+        )
+        b = TPOTClassifier(
+            generations=2,
+            population_size=5,
+            cv=3,
+            random_state=0,
+            n_jobs=-1,
+            config_dict=tpot_config,
+            use_dask=True,
+        )
+        a.fit(X, y)
+        b.fit(X, y)

--- a/tests/test_dask_based.py
+++ b/tests/test_dask_based.py
@@ -1,0 +1,38 @@
+"""Tests that ensure the dask-based fit matches.
+
+https://github.com/DEAP/deap/issues/75
+"""
+import unittest
+
+import nose
+from sklearn.datasets import make_classification
+
+from tpot import TPOTClassifier
+
+try:
+    import dask
+    import dask_ml.utils
+except ImportError:
+    raise nose.SkipTest()
+
+
+
+class TestDaskMatches(unittest.TestCase):
+    def test_dask_matches(self):
+        a = TPOTClassifier(
+            generations=2,
+            population_size=5,
+            cv=3,
+            random_state=0,
+            use_dask=False,
+        )
+        b = TPOTClassifier(
+            generations=2,
+            population_size=5,
+            cv=3,
+            random_state=0,
+            use_dask=True,
+        )
+        X, y = make_classification(random_state=0)
+        a.fit(X, y)
+        b.fit(X, y)

--- a/tests/test_dask_based.py
+++ b/tests/test_dask_based.py
@@ -17,6 +17,8 @@ except ImportError:
 
 
 class TestDaskMatches(unittest.TestCase):
+    maxDiff = None
+
     def test_dask_matches(self):
         for n_jobs in [1, -1]:
             X, y = make_classification(random_state=0)

--- a/tests/test_dask_based.py
+++ b/tests/test_dask_based.py
@@ -20,32 +20,33 @@ class TestDaskMatches(unittest.TestCase):
     maxDiff = None
 
     def test_dask_matches(self):
-        for n_jobs in [1, -1]:
-            X, y = make_classification(random_state=0)
-            a = TPOTClassifier(
-                generations=2,
-                population_size=5,
-                cv=3,
-                random_state=0,
-                n_jobs=n_jobs,
-                use_dask=False,
-            )
-            b = TPOTClassifier(
-                generations=2,
-                population_size=5,
-                cv=3,
-                random_state=0,
-                n_jobs=n_jobs,
-                use_dask=True,
-            )
-            b.fit(X, y)
-            a.fit(X, y)
+        with dask.config.set(scheduler='single-threaded'):
+            for n_jobs in [-1]:
+                X, y = make_classification(random_state=0)
+                a = TPOTClassifier(
+                    generations=2,
+                    population_size=5,
+                    cv=3,
+                    random_state=0,
+                    n_jobs=n_jobs,
+                    use_dask=False,
+                )
+                b = TPOTClassifier(
+                    generations=2,
+                    population_size=5,
+                    cv=3,
+                    random_state=0,
+                    n_jobs=n_jobs,
+                    use_dask=True,
+                )
+                b.fit(X, y)
+                a.fit(X, y)
 
-            self.assertEqual(a.score(X, y), b.score(X, y))
-            self.assertEqual(a.pareto_front_fitted_pipelines_.keys(),
-                             b.pareto_front_fitted_pipelines_.keys())
-            self.assertEqual(a.evaluated_individuals_,
-                             b.evaluated_individuals_)
+                self.assertEqual(a.score(X, y), b.score(X, y))
+                self.assertEqual(a.pareto_front_fitted_pipelines_.keys(),
+                                b.pareto_front_fitted_pipelines_.keys())
+                self.assertEqual(a.evaluated_individuals_,
+                                b.evaluated_individuals_)
 
     def test_handles_errors(self):
         X, y = make_classification(n_samples=5)

--- a/tests/test_dask_based.py
+++ b/tests/test_dask_based.py
@@ -17,7 +17,6 @@ except ImportError:
 
 
 class TestDaskMatches(unittest.TestCase):
-    maxDiff = None
 
     def test_dask_matches(self):
         with dask.config.set(scheduler='single-threaded'):
@@ -44,9 +43,9 @@ class TestDaskMatches(unittest.TestCase):
 
                 self.assertEqual(a.score(X, y), b.score(X, y))
                 self.assertEqual(a.pareto_front_fitted_pipelines_.keys(),
-                                b.pareto_front_fitted_pipelines_.keys())
+                                 b.pareto_front_fitted_pipelines_.keys())
                 self.assertEqual(a.evaluated_individuals_,
-                                b.evaluated_individuals_)
+                                 b.evaluated_individuals_)
 
     def test_handles_errors(self):
         X, y = make_classification(n_samples=5)

--- a/tests/test_dask_based.py
+++ b/tests/test_dask_based.py
@@ -10,7 +10,8 @@ from sklearn.datasets import make_classification
 from tpot import TPOTClassifier
 
 try:
-    import dask
+    import dask  # noqa
+    import dask_ml  # noqa
 except ImportError:
     raise nose.SkipTest()
 

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1165,7 +1165,7 @@ class TPOTBase(BaseEstimator):
         if self.n_jobs == 1:
             for sklearn_pipeline in sklearn_pipeline_list:
                 self._stop_by_max_time_mins()
-                val = partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline, delaeyd=self.delayed)
+                val = partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline, delayed=self.delayed)
                 result_score_list = self._update_val(val, result_score_list)
         else:
             # chunk size for pbar update

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1206,34 +1206,36 @@ class TPOTBase(BaseEstimator):
         else:
             # chunk size for pbar update
             # chunk size is min of cpu_count * 2 and n_jobs * 4
-            chunk_size = min(cpu_count()*2, self.n_jobs*4)
-            for chunk_idx in range(0, len(sklearn_pipeline_list), chunk_size):
-                self._stop_by_max_time_mins()
+            if self.use_dask:
+                import dask
 
-                if not self.use_dask:
-                    parallel = Parallel(n_jobs=self.n_jobs, verbose=0, pre_dispatch='2*n_jobs')
-                    tmp_result_scores = parallel(
-                        delayed(partial_wrapped_cross_val_score)(sklearn_pipeline=sklearn_pipeline)
-                        for sklearn_pipeline in sklearn_pipeline_list[chunk_idx:chunk_idx + chunk_size])
-                    # update pbar
-                    for val in tmp_result_scores:
-                        result_score_list = self._update_val(val, result_score_list)
+                result_score_list = [
+                    partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline)
+                    for sklearn_pipeline in sklearn_pipeline_list
+                ]
 
-                else:
-                    import dask
+                self.dask_graphs_ = result_score_list
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore')
+                    dask.compute(*result_score_list)
 
-                    tmp_result_scores = [
-                        partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline)
-                        for sklearn_pipeline in sklearn_pipeline_list[chunk_idx:chunk_idx + chunk_size]
-                    ]
-                    result_score_list.extend(tmp_result_scores)
+                self._update_pbar(len(result_score_list))
 
-                    self.dask_graphs_ = result_score_list
-                    with warnings.catch_warnings():
-                        warnings.simplefilter('ignore')
-                        result_score_list = dask.compute(*result_score_list)
+            else:
+                chunk_size = min(cpu_count()*2, self.n_jobs*4)
 
-                    self._update_pbar(len(result_score_list))
+                for chunk_idx in range(0, len(sklearn_pipeline_list), chunk_size):
+                    self._stop_by_max_time_mins()
+
+                    if not self.use_dask:
+                        parallel = Parallel(n_jobs=self.n_jobs, verbose=0, pre_dispatch='2*n_jobs')
+                        tmp_result_scores = parallel(
+                            delayed(partial_wrapped_cross_val_score)(sklearn_pipeline=sklearn_pipeline)
+                            for sklearn_pipeline in sklearn_pipeline_list[chunk_idx:chunk_idx + chunk_size])
+                        # update pbar
+                        for val in tmp_result_scores:
+                            result_score_list = self._update_val(val, result_score_list)
+
         self._update_evaluated_individuals_(result_score_list, eval_individuals_str, operator_counts, stats_dicts)
 
         """Look up the operator count and cross validation score to use in the optimization"""

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -259,7 +259,7 @@ class TPOTBase(BaseEstimator):
             will also provide more detailed diagnostics when using Dask's
             distributed scheduler.
 
-            See `<avoid repeated work <https://dask-ml.readthedocs.io/en/latest/hyper-parameter-search.html#avoid-repeated-work>`_
+            See `avoid repeated work <https://dask-ml.readthedocs.io/en/latest/hyper-parameter-search.html#avoid-repeated-work>`__
             for more.
 
         Returns
@@ -1162,7 +1162,6 @@ class TPOTBase(BaseEstimator):
         stats = deepcopy(individual_stats)  # Deepcopy, since the string reference to predecessor should be cloned
         stats['operator_count'] = operator_count
         stats['internal_cv_score'] = cv_score
-        print('combine_individual_stats', self.use_dask, stats)
         return stats
 
     def _evaluate_individuals(self, individuals, features, target, sample_weight=None, groups=None):
@@ -1349,7 +1348,6 @@ class TPOTBase(BaseEstimator):
         -------
         None
         """
-        print("update_evaluated_individuals", self.use_dask, eval_individuals_str, result_score_list)
         for result_score, individual_str in zip(result_score_list, eval_individuals_str):
             if type(result_score) in [float, np.float64, np.float32]:
                 self.evaluated_individuals_[individual_str] = self._combine_individual_stats(operator_counts[individual_str],

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1177,7 +1177,10 @@ class TPOTBase(BaseEstimator):
                                              for sklearn_pipeline in sklearn_pipeline_list[chunk_idx:chunk_idx + chunk_size]]
                 result_score_list.extend(tmp_result_scores)
 
-        result_score_list = dask.compute(*result_score_list)
+        self.dask_graphs = result_score_list
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            result_score_list = dask.compute(*result_score_list)
         self._update_pbar(len(result_score_list))
         self._update_evaluated_individuals_(result_score_list, eval_individuals_str, operator_counts, stats_dicts)
 

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -253,6 +253,14 @@ class TPOTBase(BaseEstimator):
             A setting of 2 or higher will add a progress bar during the optimization procedure.
         disable_update_check: bool, optional (default: False)
             Flag indicating whether the TPOT version checker should be disabled.
+        use_dask : bool, default False
+            Whether to use Dask-ML's pipeline optimiziations. This avoid re-fitting
+            the same estimator on the same split of data multiple times. It
+            will also provide more detailed diagnostics when using Dask's
+            distributed scheduler.
+
+            See `<avoid repeated work <https://dask-ml.readthedocs.io/en/latest/hyper-parameter-search.html#avoid-repeated-work>`_
+            for more.
 
         Returns
         -------

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1206,10 +1206,10 @@ class TPOTBase(BaseEstimator):
 
         result_score_list = []
         # Don't use parallelization if n_jobs==1
-        if self.n_jobs == 1:
+        if self.n_jobs == 1 and not self.use_dask:
             for sklearn_pipeline in sklearn_pipeline_list:
                 self._stop_by_max_time_mins()
-                val = partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline, use_dask=self.use_dask)
+                val = partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline)
                 result_score_list = self._update_val(val, result_score_list)
         else:
             # chunk size for pbar update

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1181,7 +1181,6 @@ class TPOTBase(BaseEstimator):
 
         """
 
-        self._individuals = individuals
         operator_counts, eval_individuals_str, sklearn_pipeline_list, stats_dicts = self._preprocess_individuals(individuals)
 
         # Make the partial function that will be called below
@@ -1235,12 +1234,6 @@ class TPOTBase(BaseEstimator):
                     # update pbar
                     for val in tmp_result_scores:
                         result_score_list = self._update_val(val, result_score_list)
-
-
-        self._result_score_list = result_score_list
-        self._eval_individuals_str = eval_individuals_str
-        self._operator_counts = operator_counts
-        self._stats_dicts = stats_dicts
 
         self._update_evaluated_individuals_(result_score_list, eval_individuals_str, operator_counts, stats_dicts)
 

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1162,6 +1162,7 @@ class TPOTBase(BaseEstimator):
         stats = deepcopy(individual_stats)  # Deepcopy, since the string reference to predecessor should be cloned
         stats['operator_count'] = operator_count
         stats['internal_cv_score'] = cv_score
+        print('combine_individual_stats', self.use_dask, stats)
         return stats
 
     def _evaluate_individuals(self, individuals, features, target, sample_weight=None, groups=None):
@@ -1348,6 +1349,7 @@ class TPOTBase(BaseEstimator):
         -------
         None
         """
+        print("update_evaluated_individuals", self.use_dask, eval_individuals_str, result_score_list)
         for result_score, individual_str in zip(result_score_list, eval_individuals_str):
             if type(result_score) in [float, np.float64, np.float32]:
                 self.evaluated_individuals_[individual_str] = self._combine_individual_stats(operator_counts[individual_str],

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1217,7 +1217,7 @@ class TPOTBase(BaseEstimator):
                 self.dask_graphs_ = result_score_list
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore')
-                    dask.compute(*result_score_list)
+                    result_score_list = list(dask.compute(*result_score_list))
 
                 self._update_pbar(len(result_score_list))
 

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -431,9 +431,9 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
 
     def safe_fit_and_score(*args, **kwargs):
         try:
-            return _fit_and_score(*args, **kwargs)
+            return [], _fit_and_score(*args, **kwargs), []
         except Exception:
-            return [[-float('inf'), -float('inf')]]
+            return [], [[-float('inf'), -float('inf')]], []
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -462,14 +462,14 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')
                 scores = [_fit_and_score(estimator=clone(sklearn_pipeline),
-                                        X=features,
-                                        y=target,
-                                        scorer=scorer,
-                                        train=train,
-                                        test=test,
-                                        verbose=0,
-                                        parameters=None,
-                                        fit_params=sample_weight_dict)
+                                         X=features,
+                                         y=target,
+                                         scorer=scorer,
+                                         train=train,
+                                         test=test,
+                                         verbose=0,
+                                         parameters=None,
+                                         fit_params=sample_weight_dict)
                                     for train, test in cv_iter]
                 CV_score = np.array(scores)[:, 0]
                 return np.nanmean(CV_score)

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -433,7 +433,7 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
         try:
             return _fit_and_score(*args, **kwargs)
         except Exception:
-            return -float('inf')
+            return [[-float('inf'), -float('inf')]]
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -434,8 +434,8 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
 
     if use_dask:
         try:
-            import dask_ml.model_selection
-            import dask
+            import dask_ml.model_selection  # noqa
+            import dask  # noqa
             from dask.delayed import Delayed
         except ImportError:
             msg = "'use_dask' requires the optional dask and dask-ml depedencies."
@@ -453,8 +453,10 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
             refit=False,
             error_score=float('-inf'),
         )
+
         cv_results = Delayed(keys[0], dsk)
-        scores = [cv_results['split{}_test_score'.format(i)] for i in range(n_splits)]
+        scores = [cv_results['split{}_test_score'.format(i)]
+                  for i in range(n_splits)]
         CV_score = dask.delayed(np.array)(scores)[:, 0]
         return dask.delayed(np.nanmean)(CV_score)
     else:


### PR DESCRIPTION
*I thought I submitted this already, but couldn't find it.  My apologies if this is a double-post*

*This should not be merged, it likely breaks existing behavior*

This addresses #304 .  It sprinkles dask.delayed in a couple places of the current codebase.  To improve things we should do the following:

1.  Break apart or reimplement the `_fit_and_score` function to use dask.delayed on every step of a pipeline.  This would help to improve the sharing of intermediate results and would also improve diagnostics.  `dask_ml/model_selection/_search.py::do_fit_and_score` does some of this, but it was heavily optimized for efficiency.  It would be good to do the same thing, but with dask.delayed here, which would probably be nicer for external devs even if it adds a millisecond or two of overhead.  cc @jcrist
2.  It might also be useful to delay the cross-validation process so that we don't keep passing around numpy arrays.  I suspect that we're being a bit unclean with how we're handling things there.  This may not be performance-critical near-term though.

If anyone wants to take a shot at task 1 I suspect that this would be interesting work.