### PR TITLE
Use tqdm.autonotebook to automatically choose between console or notebook

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ nose==1.3.7
 numpy==1.12.1
 scikit-learn==0.18.1
 scipy==0.19.0
-tqdm==4.11.2
+tqdm==4.26.0
 update-checker==0.16
 stopit==1.1.1
 pandas==0.20.2

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ This project is hosted at https://github.com/EpistasisLab/tpot
                     'scikit-learn>=0.18.1',
                     'deap>=1.0',
                     'update_checker>=0.16',
-                    'tqdm>=4.11.2',
+                    'tqdm>=4.26.0',
                     'stopit>=1.1.1',
                     'pandas>=0.20.2'],
     extras_require={

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -24,7 +24,7 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from tpot import TPOTClassifier, TPOTRegressor
-from tpot.base import TPOTBase, is_notebook
+from tpot.base import TPOTBase
 from tpot.driver import float_range
 from tpot.gp_types import Output_Array
 from tpot.gp_deap import mutNodeReplacement, _wrapped_cross_val_score, pick_two_individuals_eligible_for_crossover, cxOnePoint, varOr, initialize_stats_dict
@@ -63,7 +63,9 @@ from deap.tools import ParetoFront
 from nose.tools import assert_raises, assert_not_equal, assert_greater_equal, assert_equal, assert_in
 from driver_tests import captured_output
 
-from tqdm import tqdm
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    from tqdm.autonotebook import tqdm
 
 try:
     from StringIO import StringIO
@@ -155,12 +157,6 @@ def test_init_custom_parameters():
     assert tpot_obj._optimized_pipeline_score == None
     assert tpot_obj.fitted_pipeline_ == None
     assert tpot_obj._exported_pipeline_text == ""
-
-
-def test_is_notebook():
-    """Assert that isnotebook function works as expected."""
-    ret = is_notebook()
-    assert not ret
 
 
 def test_init_default_scoring():

--- a/tpot/_version.py
+++ b/tpot/_version.py
@@ -23,4 +23,4 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 """
 
-__version__ = '0.9.4'
+__version__ = '0.9.6'

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -71,6 +71,9 @@ from .config.classifier_sparse import classifier_config_sparse
 from .metrics import SCORERS
 from .gp_types import Output_Array
 from .gp_deap import eaMuPlusLambda, mutNodeReplacement, _wrapped_cross_val_score, cxOnePoint
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    from tqdm.autonotebook import tqdm
 
 # hot patch for Windows: solve the problem of crashing python after Ctrl + C in Windows OS
 # https://github.com/ContinuumIO/anaconda-issues/issues/905
@@ -93,25 +96,6 @@ if sys.platform.startswith('win'):
 
     win32api.SetConsoleCtrlHandler(handler, 1)
 
-def is_notebook():
-    """Check if TPOT is running in Jupyter notebook.
-    Returns
-    -------
-    True: TPOT is running in Jupyter notebook
-    False: TPOT is running in other terminals
-    """
-    try:
-        from IPython import get_ipython
-        shell = get_ipython().__class__.__name__
-        # if shell == 'TerminalInteractiveShell', then Terminal running IPython
-        return shell == 'ZMQInteractiveShell'
-    except:
-        return False
-
-if is_notebook():
-    from tqdm import tqdm_notebook as tqdm
-else:
-    from tqdm import tqdm
 
 
 class TPOTBase(BaseEstimator):


### PR DESCRIPTION
Since `tqdm` v4.25.0, there is a new submodule named  `autonotebook` for automatically choosing between console or notebook versions. So I updated the version of dependency and refined the `tqdm` importing.

#723 #724