### PR TITLE
random_state is inconsistency when using use_dask=True somehow

### DIFF
--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -54,7 +54,7 @@ pip install update_checker
 pip install tqdm
 pip install stopit
 pip install xgboost
-pip install dask[delayed]==0.19.2
+pip install dask[delayed]
 pip install dask-ml
 pip install cloudpickle==0.5.6
 

--- a/tests/test_dask_based.py
+++ b/tests/test_dask_based.py
@@ -20,24 +20,26 @@ class TestDaskMatches(unittest.TestCase):
     def test_dask_matches(self):
         with dask.config.set(scheduler='single-threaded'):
             for n_jobs in [-1]:
-                X, y = make_classification(random_state=0)
+                X, y = make_classification(random_state=42)
                 a = TPOTClassifier(
-                    generations=2,
+                    generations=0,
                     population_size=5,
                     cv=3,
-                    random_state=0,
+                    random_state=42,
                     n_jobs=n_jobs,
                     use_dask=False,
                 )
                 b = TPOTClassifier(
-                    generations=2,
+                    generations=0,
                     population_size=5,
                     cv=3,
-                    random_state=0,
+                    random_state=42,
                     n_jobs=n_jobs,
                     use_dask=True,
                 )
+                print('use_dask')
                 b.fit(X, y)
+                print('use_dask=False')
                 a.fit(X, y)
 
                 self.assertEqual(a.score(X, y), b.score(X, y))

--- a/tests/test_dask_based.py
+++ b/tests/test_dask_based.py
@@ -37,10 +37,8 @@ class TestDaskMatches(unittest.TestCase):
                     n_jobs=n_jobs,
                     use_dask=True,
                 )
-                print('use_dask')
-                b.fit(X, y)
-                print('use_dask=False')
                 a.fit(X, y)
+                b.fit(X, y)
 
                 self.assertEqual(a.score(X, y), b.score(X, y))
                 self.assertEqual(a.pareto_front_fitted_pipelines_.keys(),


### PR DESCRIPTION
I checked the the fitness scores and pipelines in initial population and they are all the same when use_dask=True or False with the same random state, but somehow after mutation/crossover, the mutated pipelines are different. But with the same random state, two rounds with use_dask=True has the same results in the end, so random state still works but works different between use_dask=True or False somehow. We need better workaround for this and this PR is just a patch for dev branch.