### PR TITLE
A fix of making max_time_mins work when use_dask=True

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1205,6 +1205,7 @@ class TPOTBase(BaseEstimator):
         )
 
         result_score_list = []
+
         # Don't use parallelization if n_jobs==1
         if self._n_jobs == 1 and not self.use_dask:
             for sklearn_pipeline in sklearn_pipeline_list:
@@ -1213,8 +1214,8 @@ class TPOTBase(BaseEstimator):
                 result_score_list = self._update_val(val, result_score_list)
         else:
             if self.use_dask:
+                self._stop_by_max_time_mins()
                 import dask
-
                 result_score_list = [
                     partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline)
                     for sklearn_pipeline in sklearn_pipeline_list


### PR DESCRIPTION
 `self._stop_by_max_time_mins()` was not called when use_dask=True in TPOT 0.9.5. This PR is a fix for issue #797.