### PR TITLE
Add some global flag to raise config dict import errors. I view these…

### DIFF
--- a/tpot/__init__.py
+++ b/tpot/__init__.py
@@ -26,3 +26,6 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 from ._version import __version__
 from .tpot import TPOTClassifier, TPOTRegressor
 from .driver import main
+
+# should be in the TPOTBase but there are too many factory functions to pipe it through
+_RAISE_CONFIG_DICT_ERRORS = False

--- a/tpot/operator_utils.py
+++ b/tpot/operator_utils.py
@@ -26,6 +26,7 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, TransformerMixin
 import inspect
+import tpot
 
 
 class Operator(object):
@@ -71,8 +72,12 @@ def source_decode(sourcecode):
         else:
             exec('from {} import {}'.format(import_str, op_str))
         op_obj = eval(op_str)
-    except ImportError:
-        print('Warning: {} is not available and will not be used by TPOT.'.format(sourcecode))
+    except ImportError as e:
+        if tpot._RAISE_CONFIG_DICT_ERRORS:
+            print('Error: could not import {}.'.format(sourcecode))
+            raise e
+        else:
+            print('Warning: {} is not available and will not be used by TPOT.'.format(sourcecode))
         op_obj = None
 
     return import_str, op_str, op_obj


### PR DESCRIPTION
… as dangerous when unraised. Global flag is not great, but somebody else probably knows the structure better.

PR as a discussion point. #104 comment was where this started. The error sounded like something else, not just a typo in the config dict key.