### PR TITLE
Add GAMA into docs_sources (for next version of docs)

### DIFF
--- a/docs_sources/related.md
+++ b/docs_sources/related.md
@@ -52,7 +52,7 @@ Other Automated Machine Learning (AutoML) tools and related projects:
 <tr>
 <td><a href="https://github.com/reiinakano/xcessiv">Xcessiv</a></td>
 <td>Python</td>
-<td>Apache-2.0</td>
+<td>Apache 2.0</td>
 <td>A web-based application for quick, scalable, and automated hyper-parameter tuning and stacked ensembling in Python.</td>
 </tr>
 <tr>

--- a/docs_sources/related.md
+++ b/docs_sources/related.md
@@ -55,4 +55,10 @@ Other Automated Machine Learning (AutoML) tools and related projects:
 <td>Apache-2.0</td>
 <td>A web-based application for quick, scalable, and automated hyper-parameter tuning and stacked ensembling in Python.</td>
 </tr>
+<tr>
+<td><a href="https://github.com/PGijsbers/gama">GAMA</a></td>
+<td>Python</td>
+<td>Apache 2.0</td>
+<td>Machine-learning pipeline optimization through asynchronous evaluation based genetic programming. </td>
+</tr>
 </table>


### PR DESCRIPTION
I just noticed that a new tool called [GAMA](https://github.com/PGijsbers/GAMA) recently released and it is developed by @PGijsbers. It is closely related to TPOT. The major differences are mentioned in [GAMA's docs](https://pgijsbers.github.io/gama/user_guide/index.html#tpot)