### PR TITLE
Updates the default behavior when 1st generation of indviduals is not…

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1251,7 +1251,7 @@ class TPOTBase(BaseEstimator):
             if self.verbosity > 0:
                 self._pbar.write('', file=self._file)
                 self._pbar.write('{}\nTPOT closed during evaluation in one generation.\n'
-                                    'WARNING: TPOT may not provide a good pipeline if TPOT close in a early generation.'.format(e),
+                                    'WARNING: TPOT may not provide a good pipeline if TPOT is stopped/interrupted in a early generation.'.format(e),
                                  file=self._file)
             # number of individuals already evaluated in this generation
             num_eval_ind = len(result_score_list)

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1165,12 +1165,12 @@ class TPOTBase(BaseEstimator):
         stats['internal_cv_score'] = cv_score
         return stats
 
-    def _evaluate_individuals(self, individuals, features, target, sample_weight=None, groups=None):
+    def _evaluate_individuals(self, population, features, target, sample_weight=None, groups=None):
         """Determine the fit of the provided individuals.
 
         Parameters
         ----------
-        individuals: a list of DEAP individual
+        population: a list of DEAP individual
             One individual is a list of pipeline operators and model parameters that can be
             compiled by DEAP into a callable function
         features: numpy.ndarray {n_samples, n_features}
@@ -1189,6 +1189,12 @@ class TPOTBase(BaseEstimator):
             according to its performance on the provided data
 
         """
+        # Evaluate the individuals with an invalid fitness
+        individuals = [ind for ind in population if not ind.fitness.valid]
+
+        # update pbar for valid individuals (with fitness values)
+        if self.verbosity > 0:
+            self._pbar.update(len(population)-len(individuals))
 
         operator_counts, eval_individuals_str, sklearn_pipeline_list, stats_dicts = self._preprocess_individuals(individuals)
 
@@ -1206,51 +1212,73 @@ class TPOTBase(BaseEstimator):
         )
 
         result_score_list = []
-
-        # Don't use parallelization if n_jobs==1
-        if self._n_jobs == 1 and not self.use_dask:
-            for sklearn_pipeline in sklearn_pipeline_list:
-                self._stop_by_max_time_mins()
-                val = partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline)
-                result_score_list = self._update_val(val, result_score_list)
-        else:
-            if self.use_dask:
-                self._stop_by_max_time_mins()
-                import dask
-                result_score_list = [
-                    partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline)
-                    for sklearn_pipeline in sklearn_pipeline_list
-                ]
-
-                self.dask_graphs_ = result_score_list
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore')
-                    result_score_list = list(dask.compute(*result_score_list))
-
-                self._update_pbar(len(result_score_list))
-
+        try:
+            # Don't use parallelization if n_jobs==1
+            if self._n_jobs == 1 and not self.use_dask:
+                for sklearn_pipeline in sklearn_pipeline_list:
+                    self._stop_by_max_time_mins()
+                    val = partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline)
+                    result_score_list = self._update_val(val, result_score_list)
             else:
                 # chunk size for pbar update
                 # chunk size is min of cpu_count * 2 and n_jobs * 4
                 chunk_size = min(cpu_count()*2, self._n_jobs*4)
-
                 for chunk_idx in range(0, len(sklearn_pipeline_list), chunk_size):
                     self._stop_by_max_time_mins()
+                    if self.use_dask:
+                        import dask
+                        tmp_result_scores = [
+                            partial_wrapped_cross_val_score(sklearn_pipeline=sklearn_pipeline)
+                            for sklearn_pipeline in sklearn_pipeline_list[chunk_idx:chunk_idx + chunk_size]
+                        ]
 
-                    parallel = Parallel(n_jobs=self._n_jobs, verbose=0, pre_dispatch='2*n_jobs')
-                    tmp_result_scores = parallel(
-                        delayed(partial_wrapped_cross_val_score)(sklearn_pipeline=sklearn_pipeline)
-                        for sklearn_pipeline in sklearn_pipeline_list[chunk_idx:chunk_idx + chunk_size])
+                        self.dask_graphs_ = tmp_result_scores
+                        with warnings.catch_warnings():
+                            warnings.simplefilter('ignore')
+                            tmp_result_scores = list(dask.compute(*tmp_result_scores))
+
+                    else:
+
+                        parallel = Parallel(n_jobs=self._n_jobs, verbose=0, pre_dispatch='2*n_jobs')
+                        tmp_result_scores = parallel(
+                            delayed(partial_wrapped_cross_val_score)(sklearn_pipeline=sklearn_pipeline)
+                            for sklearn_pipeline in sklearn_pipeline_list[chunk_idx:chunk_idx + chunk_size])
                     # update pbar
                     for val in tmp_result_scores:
                         result_score_list = self._update_val(val, result_score_list)
 
+        except (KeyboardInterrupt, SystemExit, StopIteration) as e:
+            if self.verbosity > 0:
+                self._pbar.write('', file=self._file)
+                self._pbar.write('{}\nTPOT closed during evaluation in one generation.'.format(e),
+                                 file=self._file)
+            # number of individuals already evaluated in this generation
+            num_eval_ind = len(result_score_list)
+            self._update_evaluated_individuals_(result_score_list,
+                                                eval_individuals_str[:num_eval_ind],
+                                                operator_counts,
+                                                stats_dicts)
+            for ind in individuals[:num_eval_ind]:
+                ind_str = str(ind)
+                ind.fitness.values = (self.evaluated_individuals_[ind_str]['operator_count'],
+                                    self.evaluated_individuals_[ind_str]['internal_cv_score'])
+            # for individuals were not evaluated in this generation, TPOT will assign a bad fitness score
+            for ind in individuals[num_eval_ind:]:
+                ind.fitness.values = (5000.,-float('inf'))
+
+            self._pareto_front.update(population)
+            raise KeyboardInterrupt
+
         self._update_evaluated_individuals_(result_score_list, eval_individuals_str, operator_counts, stats_dicts)
 
-        """Look up the operator count and cross validation score to use in the optimization"""
-        return [(self.evaluated_individuals_[str(individual)]['operator_count'],
-                 self.evaluated_individuals_[str(individual)]['internal_cv_score'])
-                for individual in individuals]
+        for ind in individuals:
+            ind_str = str(ind)
+            ind.fitness.values = (self.evaluated_individuals_[ind_str]['operator_count'],
+                                self.evaluated_individuals_[ind_str]['internal_cv_score'])
+        individuals = [ind for ind in population if not ind.fitness.valid]
+        self._pareto_front.update(population)
+
+        return population
 
     def _preprocess_individuals(self, individuals):
         """Preprocess DEAP individuals before pipeline evaluation.

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1250,7 +1250,8 @@ class TPOTBase(BaseEstimator):
         except (KeyboardInterrupt, SystemExit, StopIteration) as e:
             if self.verbosity > 0:
                 self._pbar.write('', file=self._file)
-                self._pbar.write('{}\nTPOT closed during evaluation in one generation.'.format(e),
+                self._pbar.write('{}\nTPOT closed during evaluation in one generation.\n'
+                                    'WARNING: TPOT may not provide a good pipeline if TPOT close in a early generation.'.format(e),
                                  file=self._file)
             # number of individuals already evaluated in this generation
             num_eval_ind = len(result_score_list)

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -224,18 +224,10 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
     for ind in population:
         initialize_stats_dict(ind)
 
-    # Evaluate the individuals with an invalid fitness
-    invalid_ind = [ind for ind in population if not ind.fitness.valid]
-
-    fitnesses = toolbox.evaluate(invalid_ind)
-    for ind, fit in zip(invalid_ind, fitnesses):
-        ind.fitness.values = fit
-
-    if halloffame is not None:
-        halloffame.update(population)
+    population = toolbox.evaluate(population)
 
     record = stats.compile(population) if stats is not None else {}
-    logbook.record(gen=0, nevals=len(invalid_ind), **record)
+    logbook.record(gen=0, nevals=len(population), **record)
 
     # Begin the generational process
     for gen in range(1, ngen + 1):
@@ -252,7 +244,7 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
 
         # Evaluate the individuals with an invalid fitness
         invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
-
+        """
         # update pbar for valid individuals (with fitness values)
         if not pbar.disable:
             pbar.update(len(offspring)-len(invalid_ind))
@@ -263,7 +255,9 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
 
         # Update the hall of fame with the generated individuals
         if halloffame is not None:
-            halloffame.update(offspring)
+            halloffame.update(offspring)"""
+
+        offspring = toolbox.evaluate(offspring)
 
         # Select the next generation population
         population[:] = toolbox.select(population + offspring, mu)
@@ -286,7 +280,7 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
                         )
                     )
                 pbar.write('')
-        
+
         # after each population save a periodic pipeline
         if per_generation_function is not None:
             per_generation_function(gen)


### PR DESCRIPTION
Thank @PGijsbers for the suggestions about changing default behavior when the first generation of individuals is not yet completely evaluated. We understand that the message `A pipeline has not yet been optimized. Please call fit() first.` is confused when TPOT is interrupted/stopped before 1st generation. Also TPOT users may need the best pipeline in a generation so far even that generation is not completely evaluated.  

So in this PR, TPOT can save scores of individuals already evaluated in any generation even the evaluation process of the generation is interrupted/stopped.

But it is noted that, in this case, TPOT will raise this **warning message**: `WARNING: TPOT may not provide a good pipeline if TPOT is stopped/interrupted in a early generation.`, because the pipelines in early generation, e.g. 1st generation, are evolved/modified very limited times via evolutionary algorithm. We added this warning message for avoiding misunderstanding. 

