### PR TITLE
sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn nose cython pandas pywin32
+  - conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy scikit-learn nose cython pandas pywin32 joblib
   - activate test-environment
   - pip install deap tqdm update_checker stopit dask[delayed] dask-ml cloudpickle==0.5.6
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-[please review the [contribution guidelines](http://rhiever.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]
+[please review the [Contribution Guidelines](http://epistasislab.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]
 
 ## What does this PR do?
 

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -32,7 +32,7 @@ conda update --yes conda
 # provided versions
 
 conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
-    numpy scipy scikit-learn cython pandas
+    numpy scipy scikit-learn cython pandas joblib
 
 source activate testenv
 
@@ -54,6 +54,7 @@ python --version
 python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 python -c "import sklearn; print('sklearn %s' % sklearn.__version__)"
+python -c "import joblib; print('joblib %s' % joblib.__version__)"
 python -c "import deap; print('deap %s' % deap.__version__)"
 python -c "import xgboost; print('xgboost %s ' % xgboost.__version__)"
 python -c "import update_checker; print('update_checker %s' % update_checker.__version__)"

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -13,6 +13,7 @@ python --version
 python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
 python -c "import sklearn; print('sklearn %s' % sklearn.__version__)"
+python -c "import joblib; print('joblib %s' % joblib.__version__)"
 python -c "import deap; print('deap %s' % deap.__version__)"
 python -c "import xgboost; print('xgboost %s ' % xgboost.__version__)"
 python -c "import update_checker; print('update_checker %s ' % update_checker.__version__)"

--- a/docs_sources/api.md
+++ b/docs_sources/api.md
@@ -163,7 +163,7 @@ Flag indicating whether the TPOT instance will reuse the population from previou
 Setting <em>warm_start</em>=True can be useful for running TPOT for a short time on a dataset, checking the results, then resuming the TPOT run from where it left off.
 </blockquote>
 
-<strong>memory</strong>: a sklearn.external.joblib.Memory object or string, optional (default=None)
+<strong>memory</strong>: a joblib.Memory object or string, optional (default=None)
 <blockquote>
 If supplied, pipeline will cache each transformer after calling fit. This feature is used to avoid computing the fit transformers within a pipeline if the parameters and input data are identical with another fitted pipeline during optimization process. More details about memory caching in <a href="http://scikit-learn.org/stable/modules/pipeline.html#caching-transformers-avoid-repeated-computation">scikit-learn documentation</a>
 <br /><br />
@@ -171,7 +171,7 @@ Possible inputs are:
 <ul>
 <li>String 'auto': TPOT uses memory caching with a temporary directory and cleans it up upon shutdown, or</li>
 <li>Path of a caching directory, TPOT uses memory caching with the provided directory and TPOT does NOT clean the caching directory up upon shutdown, or</li>
-<li>Memory object, TPOT uses the instance of sklearn.external.joblib.Memory for memory caching and TPOT does NOT clean the caching directory up upon shutdown, or</li>
+<li>Memory object, TPOT uses the instance of joblib.Memory for memory caching and TPOT does NOT clean the caching directory up upon shutdown, or</li>
 <li>None, TPOT does not use memory caching.</li>
 </ul>
 </blockquote>
@@ -656,7 +656,7 @@ Flag indicating whether the TPOT instance will reuse the population from previou
 Setting <em>warm_start</em>=True can be useful for running TPOT for a short time on a dataset, checking the results, then resuming the TPOT run from where it left off.
 </blockquote>
 
-<strong>memory</strong>: a sklearn.external.joblib.Memory object or string, optional (default=None)
+<strong>memory</strong>: a joblib.Memory object or string, optional (default=None)
 <blockquote>
 If supplied, pipeline will cache each transformer after calling fit. This feature is used to avoid computing the fit transformers within a pipeline if the parameters and input data are identical with another fitted pipeline during optimization process. More details about memory caching in <a href="http://scikit-learn.org/stable/modules/pipeline.html#caching-transformers-avoid-repeated-computation">scikit-learn documentation</a>
 <br /><br />
@@ -664,7 +664,7 @@ Possible inputs are:
 <ul>
 <li>String 'auto': TPOT uses memory caching with a temporary directory and cleans it up upon shutdown, or</li>
 <li>Path of a caching directory, TPOT uses memory caching with the provided directory and TPOT does NOT clean the caching directory up upon shutdown, or</li>
-<li>Memory object, TPOT uses the instance of sklearn.external.joblib.Memory for memory caching and TPOT does NOT clean the caching directory up upon shutdown, or</li>
+<li>Memory object, TPOT uses the instance of joblib.Memory for memory caching and TPOT does NOT clean the caching directory up upon shutdown, or</li>
 <li>None, TPOT does not use memory caching.</li>
 </ul>
 </blockquote>

--- a/docs_sources/installing.md
+++ b/docs_sources/installing.md
@@ -18,10 +18,10 @@ TPOT is built on top of several existing Python libraries, including:
 
 Most of the necessary Python packages can be installed via the [Anaconda Python distribution](https://www.continuum.io/downloads), which we strongly recommend that you use. We also strongly recommend that you use of Python 3 over Python 2 if you're given the choice.
 
-NumPy, SciPy, scikit-learn, and pandas can be installed in Anaconda via the command:
+NumPy, SciPy, scikit-learn, pandas and joblib can be installed in Anaconda via the command:
 
 ```Shell
-conda install numpy scipy scikit-learn pandas
+conda install numpy scipy scikit-learn pandas joblib
 ```
 
 DEAP, update_checker, tqdm and stopit can be installed with `pip` via the command:

--- a/docs_sources/using.md
+++ b/docs_sources/using.md
@@ -581,17 +581,16 @@ tpot = TPOTClassifier(generations=5,
 tpot.fit(test_X, test_y)
 ```
 
-
 # Pipeline caching in TPOT
 
-With the `memory` parameter, pipelines can cache the results of each transformer after fitting them. This feature is used to avoid repeated computation by transformers within a pipeline if the parameters and input data are identical to another fitted pipeline during optimization process. TPOT allows users to specify a custom directory path or [`sklearn.external.joblib.Memory`](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/externals/joblib/memory.py#L847) in case they want to re-use the memory cache in future TPOT runs (or a `warm_start` run).
+With the `memory` parameter, pipelines can cache the results of each transformer after fitting them. This feature is used to avoid repeated computation by transformers within a pipeline if the parameters and input data are identical to another fitted pipeline during optimization process. TPOT allows users to specify a custom directory path or [`joblib.Memory`](https://joblib.readthedocs.io/en/latest/generated/joblib.Memory.html) in case they want to re-use the memory cache in future TPOT runs (or a `warm_start` run).
 
 There are three methods for enabling memory caching in TPOT:
 
 ```Python
 from tpot import TPOTClassifier
 from tempfile import mkdtemp
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from shutil import rmtree
 
 # Method 1, auto mode: TPOT uses memory caching with a temporary directory and cleans it up upon shutdown
@@ -647,10 +646,10 @@ This will use use all the workers on your cluster to do the training, and use [D
 It will also provide fine-grained diagnostics in the [distributed scheduler UI](https://distributed.readthedocs.io/en/latest/web.html).
 
 Alternatively, Dask implements a joblib backend.
-You can instruct TPOT to use the distribued backend during training by specifying a ``joblib.parallel_backend``:
+You can instruct TPOT to use the distributed backend during training by specifying a ``joblib.parallel_backend``:
 
 ```python
-from sklearn.externals import joblib
+import joblib
 import distributed.joblib
 from dask.distributed import Client
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tqdm==4.26.0
 update-checker==0.16
 stopit==1.1.1
 pandas==0.20.2
+joblib=0.10.3

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ This project is hosted at https://github.com/EpistasisLab/tpot
                     'update_checker>=0.16',
                     'tqdm>=4.26.0',
                     'stopit>=1.1.1',
-                    'pandas>=0.20.2'],
+                    'pandas>=0.20.2',
+                    'joblib>=0.10.3'],
     extras_require={
         'xgboost': ['xgboost==0.6a2'],
         'skrebate': ['skrebate>=0.3.4'],

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -55,7 +55,7 @@ from shutil import rmtree
 
 from sklearn.datasets import load_digits, load_boston, make_classification
 from sklearn.model_selection import train_test_split, cross_val_score, GroupKFold
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from sklearn.metrics import make_scorer, roc_auc_score
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, TransformerMixin
 from sklearn.feature_selection.base import SelectorMixin

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -48,11 +48,12 @@ from copy import copy, deepcopy
 
 from sklearn.base import BaseEstimator
 from sklearn.utils import check_X_y, check_consistent_length, check_array
-from sklearn.externals.joblib import Parallel, delayed, Memory
 from sklearn.pipeline import make_pipeline, make_union
 from sklearn.preprocessing import FunctionTransformer, Imputer
 from sklearn.model_selection import train_test_split
 from sklearn.metrics.scorer import make_scorer, _BaseScorer
+
+from joblib import Parallel, delayed, Memory
 
 from update_checker import update_check
 
@@ -229,7 +230,7 @@ class TPOTBase(BaseEstimator):
                 the caching directory up upon shutdown. If the directory does not exist, TPOT will
                 create it.
             Memory object:
-                TPOT uses the instance of sklearn.external.joblib.Memory for memory caching,
+                TPOT uses the instance of joblib.Memory for memory caching,
                 and TPOT does NOT clean the caching directory up upon shutdown.
             None:
                 TPOT does not use memory caching.
@@ -804,7 +805,7 @@ class TPOTBase(BaseEstimator):
             else:
                 raise ValueError(
                     'Could not recognize Memory object for pipeline caching. '
-                    'Please provide an instance of sklearn.external.joblib.Memory,'
+                    'Please provide an instance of joblib.Memory,'
                     ' a path to a directory on your system, or \"auto\".'
                 )
 


### PR DESCRIPTION
## What does this PR do?
sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. This PR adds joblib as an explicit dependency.

joblib 0.10.3 is used as the minimum version since it is the version included in scikit-learn 0.18.1.
https://github.com/scikit-learn/scikit-learn/blob/a5ab948cbc366d705b1f8db8687c7162f51de22d/sklearn/externals/joblib/__init__.py#L119

## Where should the reviewer start?

tpot/base.py 

## How should this PR be tested?

Regular unit test suite

## Any background context you want to provide?

https://scikit-learn.org/stable/whats_new.html#id40

## What are the relevant issues?

None

## Screenshots (if appropriate)

N/A

## Questions:

- Do the docs need to be updated? Yes
- Does this PR add new (Python) dependencies? Yes
