### PR TITLE
Add explicit XGBoostRegressor objective to avoid deprecation error

### DIFF
--- a/tpot/config/regressor.py
+++ b/tpot/config/regressor.py
@@ -101,7 +101,8 @@ regressor_config_dict = {
         'learning_rate': [1e-3, 1e-2, 1e-1, 0.5, 1.],
         'subsample': np.arange(0.05, 1.01, 0.05),
         'min_child_weight': range(1, 21),
-        'nthread': [1]
+        'nthread': [1],
+        'objective': ['reg:squarederror']
     },
 
     # Preprocesssors

--- a/tpot/config/regressor_sparse.py
+++ b/tpot/config/regressor_sparse.py
@@ -94,5 +94,6 @@ regressor_config_sparse = {
         'learning_rate': [1e-3, 1e-2, 1e-1, 0.5, 1.],
         'subsample': np.arange(0.05, 1.01, 0.05),
         'min_child_weight': range(1, 21),
-        'nthread': [1]
+        'nthread': [1],
+        'objective': ['reg:squarederror']
     }}


### PR DESCRIPTION
## What does this PR do?
Set the objective for XGBoostRegressors explicitly to reg:squarederror to prevent deprecation warnings.

## Where should the reviewer start?
tpot\tpot\config\regressor.py and tpot\tpot\config\regressor_sparse.py


## How should this PR be tested?
From my point of view it it not needed.


## Any background context you want to provide?



## What are the relevant issues?
Currently when including XGBoostRegressors in the pipeline the logs are spammed with deprecation warnings. 

Related partially to problems mentioned in #877 .

## Screenshots (if appropriate)


## Questions:

- Do the docs need to be updated? No
- Does this PR add new (Python) dependencies? No
