### PR TITLE
Refine imputer import for latest version sklearn

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -455,7 +455,7 @@ Feature matrix
 <br /><br />
 TPOT and all scikit-learn algorithms assume that the features will be numerical and there will be no missing values.
 As such, when a feature matrix is provided to TPOT, all missing values will automatically be replaced (i.e., imputed)
-using <a href="http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.Imputer.html">median value imputation</a>.
+using <a href="http://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html">median value imputation</a>.
 <br /><br />
 If you wish to use a different imputation strategy than median imputation, please make sure to apply imputation to your feature set prior to passing it to TPOT.
 </blockquote>
@@ -923,7 +923,7 @@ Feature matrix
 <br /><br />
 TPOT and all scikit-learn algorithms assume that the features will be numerical and there will be no missing values.
 As such, when a feature matrix is provided to TPOT, all missing values will automatically be replaced (i.e., imputed)
-using <a href="http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.Imputer.html">median value imputation</a>.
+using <a href="http://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html">median value imputation</a>.
 <br /><br />
 If you wish to use a different imputation strategy than median imputation, please make sure to apply imputation to your feature set prior to passing it to TPOT.
 </blockquote>

--- a/docs/index.html
+++ b/docs/index.html
@@ -213,5 +213,5 @@
 
 <!--
 MkDocs version : 0.17.2
-Build Date UTC : 2019-06-13 13:26:54
+Build Date UTC : 2019-07-16 14:58:41
 -->

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,7 +4,7 @@
     
     <url>
      <loc>http://epistasislab.github.io/tpot/</loc>
-     <lastmod>2019-06-13</lastmod>
+     <lastmod>2019-07-16</lastmod>
      <changefreq>daily</changefreq>
     </url>
     
@@ -12,7 +12,7 @@
     
     <url>
      <loc>http://epistasislab.github.io/tpot/installing/</loc>
-     <lastmod>2019-06-13</lastmod>
+     <lastmod>2019-07-16</lastmod>
      <changefreq>daily</changefreq>
     </url>
     
@@ -20,7 +20,7 @@
     
     <url>
      <loc>http://epistasislab.github.io/tpot/using/</loc>
-     <lastmod>2019-06-13</lastmod>
+     <lastmod>2019-07-16</lastmod>
      <changefreq>daily</changefreq>
     </url>
     
@@ -28,7 +28,7 @@
     
     <url>
      <loc>http://epistasislab.github.io/tpot/api/</loc>
-     <lastmod>2019-06-13</lastmod>
+     <lastmod>2019-07-16</lastmod>
      <changefreq>daily</changefreq>
     </url>
     
@@ -36,7 +36,7 @@
     
     <url>
      <loc>http://epistasislab.github.io/tpot/examples/</loc>
-     <lastmod>2019-06-13</lastmod>
+     <lastmod>2019-07-16</lastmod>
      <changefreq>daily</changefreq>
     </url>
     
@@ -44,7 +44,7 @@
     
     <url>
      <loc>http://epistasislab.github.io/tpot/contributing/</loc>
-     <lastmod>2019-06-13</lastmod>
+     <lastmod>2019-07-16</lastmod>
      <changefreq>daily</changefreq>
     </url>
     
@@ -52,7 +52,7 @@
     
     <url>
      <loc>http://epistasislab.github.io/tpot/releases/</loc>
-     <lastmod>2019-06-13</lastmod>
+     <lastmod>2019-07-16</lastmod>
      <changefreq>daily</changefreq>
     </url>
     
@@ -60,7 +60,7 @@
     
     <url>
      <loc>http://epistasislab.github.io/tpot/citing/</loc>
-     <lastmod>2019-06-13</lastmod>
+     <lastmod>2019-07-16</lastmod>
      <changefreq>daily</changefreq>
     </url>
     
@@ -68,7 +68,7 @@
     
     <url>
      <loc>http://epistasislab.github.io/tpot/support/</loc>
-     <lastmod>2019-06-13</lastmod>
+     <lastmod>2019-07-16</lastmod>
      <changefreq>daily</changefreq>
     </url>
     
@@ -76,7 +76,7 @@
     
     <url>
      <loc>http://epistasislab.github.io/tpot/related/</loc>
-     <lastmod>2019-06-13</lastmod>
+     <lastmod>2019-07-16</lastmod>
      <changefreq>daily</changefreq>
     </url>
     

--- a/docs_sources/api.md
+++ b/docs_sources/api.md
@@ -321,7 +321,7 @@ Feature matrix
 <br /><br />
 TPOT and all scikit-learn algorithms assume that the features will be numerical and there will be no missing values.
 As such, when a feature matrix is provided to TPOT, all missing values will automatically be replaced (i.e., imputed)
-using <a href="http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.Imputer.html">median value imputation</a>.
+using <a href="http://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html">median value imputation</a>.
 <br /><br />
 If you wish to use a different imputation strategy than median imputation, please make sure to apply imputation to your feature set prior to passing it to TPOT.
 </blockquote>
@@ -809,7 +809,7 @@ Feature matrix
 <br /><br />
 TPOT and all scikit-learn algorithms assume that the features will be numerical and there will be no missing values.
 As such, when a feature matrix is provided to TPOT, all missing values will automatically be replaced (i.e., imputed)
-using <a href="http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.Imputer.html">median value imputation</a>.
+using <a href="http://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html">median value imputation</a>.
 <br /><br />
 If you wish to use a different imputation strategy than median imputation, please make sure to apply imputation to your feature set prior to passing it to TPOT.
 </blockquote>

--- a/tests/export_tests.py
+++ b/tests/export_tests.py
@@ -602,7 +602,10 @@ def test_imputer_in_export():
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.neighbors import KNeighborsClassifier
-from sklearn.preprocessing import Imputer
+try:
+    from sklearn.impute import SimpleImputer as Imputer
+except ImportError:
+    from sklearn.preprocessing import Imputer
 
 # NOTE: Make sure that the class is labeled 'target' in the data file
 tpot_data = pd.read_csv('PATH/TO/DATA/FILE', sep='COLUMN_SEPARATOR', dtype=np.float64)

--- a/tpot/_version.py
+++ b/tpot/_version.py
@@ -23,4 +23,4 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 """
 
-__version__ = '0.10.1'
+__version__ = '0.10.2'

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -49,7 +49,11 @@ from copy import copy, deepcopy
 from sklearn.base import BaseEstimator
 from sklearn.utils import check_X_y, check_consistent_length, check_array
 from sklearn.pipeline import make_pipeline, make_union
-from sklearn.preprocessing import FunctionTransformer, Imputer
+from sklearn.preprocessing import FunctionTransformer
+try:
+    from sklearn.impute import SimpleImputer as Imputer
+except ImportError:
+    from sklearn.preprocessing import Imputer
 from sklearn.model_selection import train_test_split
 from sklearn.metrics.scorer import make_scorer, _BaseScorer
 

--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -200,10 +200,6 @@ def generate_import_code(pipeline, operators, impute=False):
     # Build dict of import requirments from list of operators
     import_relations = {op.__name__: op.import_hash for op in operators}
 
-    # Add the imputer if necessary
-    if impute:
-        pipeline_imports['sklearn.preprocessing'] = ['Imputer']
-
     # Build import dict from operators used
     for op in operators_used:
         try:
@@ -216,6 +212,14 @@ def generate_import_code(pipeline, operators, impute=False):
     for key in sorted(pipeline_imports.keys()):
         module_list = ', '.join(sorted(pipeline_imports[key]))
         pipeline_text += 'from {} import {}\n'.format(key, module_list)
+
+    # Add the imputer if necessary
+    if impute:
+        pipeline_text += """try:
+    from sklearn.impute import SimpleImputer as Imputer
+except ImportError:
+    from sklearn.preprocessing import Imputer
+"""
 
     return pipeline_text
 


### PR DESCRIPTION
Related issue #889 

We will have a minor release of TPOT with this fix and this minor version of TPOT will be the last version of TPOT which supports Python2.