### PR TITLE
Allow for Flexible Preprocessing

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -481,8 +481,11 @@ class TPOTBase(BaseEstimator):
 
 
     def _add_operators(self):
-        def add_randomtree():
-            step_in_type = np.ndarray
+        def add_randomtree(ret_types=[]):
+            if len(ret_types) > 0:
+                step_in_type = ret_types[-1]
+            else:
+                step_in_type = np.ndarray
             step_ret_type = Output_Array
             for operator in self.operators:
                 arg_types =  operator.parameter_types()[0][1:]
@@ -522,7 +525,7 @@ class TPOTBase(BaseEstimator):
                 if step == 'CombineDFs':
                     self._pset.addPrimitive(CombineDFs(), [step_in_type, step_in_type], step_in_type)
                 elif step == 'RandomTree':
-                    add_randomtree()
+                    add_randomtree(ret_types)
                 elif main_type.count(step): # if the step is a main type
                     for operator in self.operators:
                         arg_types =  operator.parameter_types()[0][1:]

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -427,10 +427,7 @@ class TPOTBase(BaseEstimator):
 
 
     def _add_operators(self):
-        main_type = ["Classifier", "Regressor", "Selector", "Transformer"]
-        ret_types = []
-        self.op_list = []
-        if self.template == None: # default pipeline structure
+        def add_randomtree():
             step_in_type = np.ndarray
             step_ret_type = Output_Array
             for operator in self.operators:
@@ -445,6 +442,12 @@ class TPOTBase(BaseEstimator):
                 self._pset.addPrimitive(operator, *tree_p_types)
                 self._import_hash_and_add_terminals(operator, arg_types)
             self._pset.addPrimitive(CombineDFs(), [step_in_type, step_in_type], step_in_type)
+            
+        main_type = ["Classifier", "Regressor", "Selector", "Transformer"]
+        ret_types = []
+        self.op_list = []
+        if self.template == None or self.template == 'RandomTree': # default pipeline structure
+            add_randomtree()
         else:
             gp_types = {}
             for idx, step in enumerate(self._template_comp):
@@ -464,6 +467,8 @@ class TPOTBase(BaseEstimator):
                         step_ret_type = Output_Array
                 if step == 'CombineDFs':
                     self._pset.addPrimitive(CombineDFs(), [step_in_type, step_in_type], step_in_type)
+                elif step == 'RandomTree':
+                    add_randomtree()
                 elif main_type.count(step): # if the step is a main type
                     for operator in self.operators:
                         arg_types =  operator.parameter_types()[0][1:]

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -397,6 +397,10 @@ class TPOTBase(BaseEstimator):
             self._config_dict = self.default_config_dict
 
     def _setup_preprocess_config(self, config_dict):
+        if self.template is None:
+            self.template = 'RandomTree'
+        elif 'PreprocessTransformer' in self.template:
+            return
         if config_dict:
             # check for valid keys...
             preprocess_keys = ['text_columns', 'numeric_columns', 'categorical_columns', 'impute']
@@ -433,10 +437,11 @@ class TPOTBase(BaseEstimator):
                         else:
                             column_transform_dict[k] = [config_dict[k]]
             self._config_dict['tpot.builtins.PreprocessTransformer'] = column_transform_dict
+            self.config_dict = copy(self._config_dict)
             if self.template is None:
                 self.template = "PreprocessTransformer-RandomTree"
             else:
-                self.template = "{}-{}".format(PreprocessTransformer, self.template)
+                self.template = "{}-{}".format('PreprocessTransformer', self.template)
         else:
             self._preprocess_config_dict = {}
 

--- a/tpot/builtins/__init__.py
+++ b/tpot/builtins/__init__.py
@@ -29,3 +29,4 @@ from .stacking_estimator import StackingEstimator
 from .one_hot_encoder import OneHotEncoder, auto_select_categorical_features, _transform_selected
 from .feature_transformers import CategoricalSelector, ContinuousSelector
 from .feature_set_selector import FeatureSetSelector
+from .preprocessing import IdentityTransformer, PreprocessTransformer

--- a/tpot/builtins/preprocessing.py
+++ b/tpot/builtins/preprocessing.py
@@ -1,0 +1,91 @@
+
+import sys
+import os
+from importlib import import_module
+
+from sklearn.base import TransformerMixin, BaseEstimator
+from sklearn.feature_extraction.text import TfidfVectorizer, CountVectorizer, HashingVectorizer
+from sklearn.preprocessing import OneHotEncoder
+from importlib import import_module
+from sklearn.compose import ColumnTransformer
+
+import_loader = {
+    'TfidfVectorizer': TfidfVectorizer,
+    'CountVectorizer': CountVectorizer,
+    'HashingVectorizer': HashingVectorizer,
+    'OneHotEncoder': OneHotEncoder
+}
+
+
+
+def load_scoring_function(scoring_func):
+    """
+    converts mymodule.myfunc in the myfunc
+    object itself so tpot receives a scoring function
+    """
+    if scoring_func and ("." in scoring_func):
+        try:
+            module_name, func_name = scoring_func.rsplit('.', 1)
+
+            module_path = os.getcwd()
+            sys.path.insert(0, module_path)
+            scoring_func = getattr(import_module(module_name), func_name)
+            sys.path.pop(0)
+
+            print('manual scoring function: {}'.format(scoring_func))
+            print('taken from module: {}'.format(module_name))
+        except Exception as e:
+            print('failed importing custom scoring function, error: {}'.format(str(e)))
+            raise ValueError(e)
+
+    return scoring_func
+
+class IdentityTransformer(TransformerMixin, BaseEstimator):
+    """Identity-transformer for doing literally nothing"""
+    def fit(self, X, y=None, **fit_params):
+        return self
+    def transform(self, X):
+        return X
+
+class PreprocessTransformer(TransformerMixin):
+    def __init__(self, numeric_columns=[], categorical_columns=[], text_columns=[],
+    text_transformer = 'TfIdfVectorizer', categorical_transformer = 'OneHotEncoder'):
+        self.numeric_columns = numeric_columns
+        self.categorical_columns = categorical_columns
+        self.text_columns = text_columns
+        self.text_transformer = text_transformer
+        self.categorical_transformer = categorical_transformer
+        
+    def _setup_columns(self):
+        def text_to_list(text):
+            if type(text) is list:
+                return text
+            return [text]
+
+        self.numeric_columns = text_to_list(self.numeric_columns)
+        self.categorical_columns = text_to_list(self.categorical_columns)
+        self.text_columns = text_to_list(self.text_columns)
+
+        column_list = []
+        if len(self.text_columns) > 0:
+            load_func = import_loader.get(self.text_transformer, self.text_transformer)
+            load_func = load_scoring_function(load_func)
+            for idx, text in enumerate(self.text_columns):
+                column_list.append(('text' + str(idx), load_func, text))
+        
+        if len(self.numeric_columns) > 0:
+            column_list.append(('numeric', IdentityTransformer(), self.numeric_columns))
+        
+        if len(self.categorical_columns) > 0:
+            load_func = import_loader.get(self.categorical_transformer, self.categorical_transformer)
+            load_func = load_scoring_function(load_func)
+            column_list.append(('categorical', load_func, self.categorical_columns))
+        
+        self.column_transformer = ColumnTransformer(column_list)
+
+    def fit(self, X, y=None):
+        self._setup_columns()
+        self.column_transformer.fit(X, y)
+        return self
+    def transform(self, X):
+        return self.column_transformer.transform(X)  

--- a/tpot/builtins/preprocessing.py
+++ b/tpot/builtins/preprocessing.py
@@ -49,7 +49,7 @@ class IdentityTransformer(TransformerMixin, BaseEstimator):
 
 class PreprocessTransformer(TransformerMixin):
     def __init__(self, numeric_columns=[], categorical_columns=[], text_columns=[],
-    text_transformer = 'TfIdfVectorizer', categorical_transformer = 'OneHotEncoder'):
+    text_transformer = 'TfidfVectorizer', categorical_transformer = 'OneHotEncoder'):
         self.numeric_columns = numeric_columns
         self.categorical_columns = categorical_columns
         self.text_columns = text_columns
@@ -69,17 +69,19 @@ class PreprocessTransformer(TransformerMixin):
         column_list = []
         if len(self.text_columns) > 0:
             load_func = import_loader.get(self.text_transformer, self.text_transformer)
-            load_func = load_scoring_function(load_func)
+            if isinstance(load_func, str):
+                load_func = load_scoring_function(load_func)
             for idx, text in enumerate(self.text_columns):
-                column_list.append(('text' + str(idx), load_func, text))
+                column_list.append(('text' + str(idx), load_func(), text))
         
         if len(self.numeric_columns) > 0:
             column_list.append(('numeric', IdentityTransformer(), self.numeric_columns))
         
         if len(self.categorical_columns) > 0:
             load_func = import_loader.get(self.categorical_transformer, self.categorical_transformer)
-            load_func = load_scoring_function(load_func)
-            column_list.append(('categorical', load_func, self.categorical_columns))
+            if isinstance(load_func, str):
+                load_func = load_scoring_function(load_func)
+            column_list.append(('categorical', load_func(), self.categorical_columns))
         
         self.column_transformer = ColumnTransformer(column_list)
 


### PR DESCRIPTION
[please review the [Contribution Guidelines](http://epistasislab.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

Too many things - so many things that I'm pretty sure there will be discussions on whether this is the way to proceed. Putting it up here before I invest more time on it. This PR addresses several items (possibly too many again) including

#507 
#836 
Handling of categorical data #771 - I know its not directly related; but it is the closest issue, and in my mind it would allow for extending it to using different encodings like using this: https://github.com/scikit-learn-contrib/categorical-encoding

Which are all related to how TPOT does preprocessing. This PR does a number of things including re-introducing "RandomTree" option in templates that allows specifying templates in the form `Transformer-RandomTree`; which will then allow things like `My_Preprocessing-RandomTree`.

The high level approach is to inject additional preprocessing steps when `_fit_init` is called which then alters the behaviour of TPOT. 

## Where should the reviewer start?

`tpot/base.py` - will add comments in files as part of this PR with my thoughts...

Also can't get relative imports working - so that would be appreciated for the `tpot.drivers.load_scoring_function` part


## How should this PR be tested?

Happy to add new tests later; when the design is approved...

## Any background context you want to provide?

NIL see above

## What are the relevant issues?

#507 
#836 
Handling of categorical data #771 

## Screenshots (if appropriate)

Example of API using modified Iris dataset

```py
from tpot import TPOTClassifier
from sklearn.datasets import load_iris
from sklearn.model_selection import train_test_split
import numpy as np
import pandas as pd

iris = load_iris()
X_train, X_test, y_train, y_test = train_test_split(iris.data.astype(np.float64),
    iris.target.astype(np.float64), train_size=0.75, test_size=0.25)

tpot = TPOTClassifier(generations=1, population_size=5, verbosity=2, template="PCA-RandomTree")

X_train_df = pd.DataFrame(X_train, columns=["num1", "num2", "num3", "num4"])
X_train_df['text'] = np.random.choice(["hello", "world", "foo", "bar world", "bar hello"], X_train.shape[0])

tpot2 = TPOTClassifier(generations=1, population_size=5, verbosity=2, template="PCA-LogisticRegression", 
                      preprocess_config_dict = {
                          'numeric_columns': ["num2"]
                      })
tpot2.fit(X_train_df, y_train)

tpot2 = TPOTClassifier(generations=1, population_size=5, verbosity=2, template="PCA-LogisticRegression", 
                      preprocess_config_dict = {
                          'numeric_columns': ["num2", "num3", "num4"]
                      })
tpot2.fit(X_train_df, y_train)

tpot2 = TPOTClassifier(generations=1, population_size=5, verbosity=2, template="PCA-LogisticRegression", 
                      preprocess_config_dict = {
                          'numeric_columns': ["num2"],
                          'text_columns': ['text']
                      })
tpot2.fit(X_train_df, y_train)
```

```
Generation 1 - Current best internal CV score: 0.5908385093167702

Best pipeline: LogisticRegression(PCA(PreprocessTransformer(input_matrix, numeric_columns=['num2']), iterated_power=2, svd_solver=randomized), C=20.0, dual=True, penalty=l2)

Generation 1 - Current best internal CV score: 0.9556935817805383

Best pipeline: LogisticRegression(PCA(PreprocessTransformer(input_matrix, numeric_columns=['num2', 'num3', 'num4']), iterated_power=9, svd_solver=randomized), C=20.0, dual=False, penalty=l1)

Generation 1 - Current best internal CV score: 0.5096273291925466
```


## Questions:

- Do the docs need to be updated? Yes - will do later
- Does this PR add new (Python) dependencies? No
