### PR TITLE
The operator to specify the version of joblib is invalid

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ tqdm==4.26.0
 update-checker==0.16
 stopit==1.1.1
 pandas==0.20.2
-joblib=0.10.3
+joblib==0.10.3


### PR DESCRIPTION
## What does this PR do?

The operator to specify the version of joblib is invalid.

```console
$ python3.7 -m venv venv
$ source venv/bin/activate
(venv) $ pip install -r requirements.txt
Invalid requirement: 'joblib=0.10.3'
= is not a valid operator. Did you mean == ?
```

## Where should the reviewer start?



## How should this PR be tested?

Please execute `pip install -r requirements.txt`

## Any background context you want to provide?

nothing

## What are the relevant issues?

nothing

## Screenshots (if appropriate)

no needed

## Questions:

- Do the docs need to be updated? no
- Does this PR add new (Python) dependencies? no
