### PR TITLE
added a boolean switch to export to screen instead of to file

### DIFF
--- a/tests/export_tests.py
+++ b/tests/export_tests.py
@@ -104,6 +104,38 @@ def test_export():
     remove("test_export.py") # clean up exported file
 
 
+def test_export_2():
+    """Assert that TPOT's export function returns the expected pipeline text as a string."""
+
+    pipeline_string = (
+        'KNeighborsClassifier('
+        'input_matrix, '
+        'KNeighborsClassifier__n_neighbors=10, '
+        'KNeighborsClassifier__p=1, '
+        'KNeighborsClassifier__weights=uniform'
+        ')'
+    )
+    pipeline = creator.Individual.from_string(pipeline_string, tpot_obj._pset)
+    tpot_obj._optimized_pipeline = pipeline
+    expected_code = """import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.neighbors import KNeighborsClassifier
+
+# NOTE: Make sure that the class is labeled 'target' in the data file
+tpot_data = pd.read_csv('PATH/TO/DATA/FILE', sep='COLUMN_SEPARATOR', dtype=np.float64)
+features = tpot_data.drop('target', axis=1).values
+training_features, testing_features, training_target, testing_target = \\
+            train_test_split(features, tpot_data['target'].values, random_state=None)
+
+exported_pipeline = KNeighborsClassifier(n_neighbors=10, p=1, weights="uniform")
+
+exported_pipeline.fit(training_features, training_target)
+results = exported_pipeline.predict(testing_features)
+"""
+    assert expected_code == tpot_obj.export()
+
+
 def test_generate_pipeline_code():
     """Assert that generate_pipeline_code() returns the correct code given a specific pipeline."""
 
@@ -559,7 +591,7 @@ features = tpot_data.drop('target', axis=1).values
 training_features, testing_features, training_target, testing_target = \\
             train_test_split(features, tpot_data['target'].values, random_state=None)
 
-# Average CV score on the training set was:0.929813743
+# Average CV score on the training set was: 0.929813743
 exported_pipeline = make_pipeline(
     SelectPercentile(score_func=f_classif, percentile=20),
     DecisionTreeClassifier(criterion="gini", max_depth=8, min_samples_leaf=5, min_samples_split=5)

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1088,16 +1088,18 @@ class TPOTBase(BaseEstimator):
                 raise ValueError('Failed creating the periodic_checkpoint_folder:\n{}'.format(e))
 
 
-    def export(self, output_file_name, data_file_path=''):
+    def export(self, output_file_name='tpot_pipeline.py', data_file_path='', to_screen=False):
         """Export the optimized pipeline as Python code.
 
         Parameters
         ----------
-        output_file_name: string
+        output_file_name: string (default: 'tpot_pipeline.py')
             String containing the path and file name of the desired output file
         data_file_path: string (default: '')
             By default, the path of input dataset is 'PATH/TO/DATA/FILE' by default.
             If data_file_path is another string, the path will be replaced.
+        to_screen: boolean (default: False)
+            If set to True, the full text of the export is printed to screen instead of to file.
 
         Returns
         -------
@@ -1114,9 +1116,11 @@ class TPOTBase(BaseEstimator):
                                     self.random_state,
                                     data_file_path=data_file_path)
 
-        with open(output_file_name, 'w') as output_file:
-            output_file.write(to_write)
-
+        if to_screen:
+            print(to_write)
+        else:
+            with open(output_file_name, 'w') as output_file:
+                output_file.write(to_write)
 
     def _impute_values(self, features):
         """Impute missing values in a feature set.

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1088,24 +1088,21 @@ class TPOTBase(BaseEstimator):
                 raise ValueError('Failed creating the periodic_checkpoint_folder:\n{}'.format(e))
 
 
-    def export(self, output_file_name='tpot_pipeline.py', data_file_path='', to_screen=False):
+    def export(self, output_file_name='', data_file_path=''):
         """Export the optimized pipeline as Python code.
 
         Parameters
         ----------
-        output_file_name: string (default: 'tpot_pipeline.py')
-            String containing the path and file name of the desired output file
+        output_file_name: string (default: '')
+            String containing the path and file name of the desired output file. If left empty, writing to file will be skipped.
         data_file_path: string (default: '')
             By default, the path of input dataset is 'PATH/TO/DATA/FILE' by default.
             If data_file_path is another string, the path will be replaced.
-        to_screen: boolean (default: False)
-            If set to True, the full text of the export is printed to screen instead of to file.
 
         Returns
         -------
-        False if it skipped writing the pipeline to file
-        True if the pipeline was actually written
-
+        to_write: str
+            The whole pipeline text as a string.
         """
         if self._optimized_pipeline is None:
             raise RuntimeError('A pipeline has not yet been optimized. Please call fit() first.')
@@ -1116,11 +1113,11 @@ class TPOTBase(BaseEstimator):
                                     self.random_state,
                                     data_file_path=data_file_path)
 
-        if to_screen:
-            print(to_write)
-        else:
+        if output_file_name is not '':
             with open(output_file_name, 'w') as output_file:
                 output_file.write(to_write)
+        return to_write
+
 
     def _impute_values(self, features):
         """Impute missing values in a feature set.

--- a/tpot/export_utils.py
+++ b/tpot/export_utils.py
@@ -113,7 +113,7 @@ testing_features = imputer.transform(testing_features)
 """
 
     if pipeline_score is not None:
-        pipeline_text += '\n# Average CV score on the training set was:{}'.format(pipeline_score)
+        pipeline_text += '\n# Average CV score on the training set was: {}'.format(pipeline_score)
     pipeline_text += '\n'
 
     # Replace the function calls with their corresponding Python code


### PR DESCRIPTION
## What does this PR do?
Fixes #938 by providing `.export()` with a new parameter; `to_screen`. If set to `True` export prints to screen instead of to file.

## Where should the reviewer start?
Try exporting to screen instead of to file!

## Discussion
I had to provide `output_file_name` with a default value. If not, a user would still have to provide a filename even when only exporting to screen.

## Documentation
Please see this as a suggestion. If agreed upon I can add some commits updating the docs before making this PR final (if needed).