### PR TITLE
allow both max_time_mins and generations as valid parameters concurre…

### DIFF
--- a/docs_sources/api.md
+++ b/docs_sources/api.md
@@ -34,7 +34,7 @@ Read more in the [User Guide](using/#tpot-with-code).
 <td width="80%" style="background:white;">
 <strong>generations</strong>: int, optional (default=100)
 <blockquote>
-Number of iterations to the run pipeline optimization process. Must be a positive number.
+Number of iterations to the run pipeline optimization process. Must be a positive number or None. If None, the parameter <em>max_time_mins</em> must be defined as the runtime limit.
 <br /><br />
 Generally, TPOT will work better when you give it more generations (and therefore time) to optimize the pipeline.
 <br /><br />

--- a/docs_sources/api.md
+++ b/docs_sources/api.md
@@ -115,7 +115,7 @@ Setting <em>n_jobs</em>=-1 will use as many cores as available on the computer. 
 <blockquote>
 How many minutes TPOT has to optimize the pipeline.
 <br /><br />
-If not None, this setting will override the <em>generations</em> parameter and allow TPOT to run until <em>max_time_mins</em> minutes elapse.
+If not None, this setting will allow TPOT to run until <em>max_time_mins</em> minutes elapsed and then stop. TPOT will stop earlier if <em>generations</em> is set and all generations are already evaluated.
 </blockquote>
 
 <strong>max_eval_time_mins</strong>: float, optional (default=5)

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -275,9 +275,17 @@ def test_invalid_mut_rate_plus_xo_rate():
 
 def test_init_max_time_mins():
     """Assert that the TPOT init stores max run time and sets generations to 1000000."""
-    tpot_obj = TPOTClassifier(max_time_mins=30, generations=1000)
+    tpot_obj = TPOTClassifier(max_time_mins=30, generations=None)
     tpot_obj._fit_init()
     assert tpot_obj.generations == 1000000
+    assert tpot_obj.max_time_mins == 30
+
+
+def test_init_max_time_mins_and_generations():
+    """Assert that the TPOT init stores max run time but keeps the generations at the user-supplied value."""
+    tpot_obj = TPOTClassifier(max_time_mins=30, generations=1000)
+    tpot_obj._fit_init()
+    assert tpot_obj.generations == 1000
     assert tpot_obj.max_time_mins == 30
 
 
@@ -945,7 +953,7 @@ def test_fit_4():
     tpot_obj = TPOTClassifier(
         random_state=42,
         population_size=2,
-        generations=1,
+        generations=None,
         verbosity=0,
         max_time_mins=2/60.,
         config_dict='TPOT light'

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -566,9 +566,11 @@ class TPOTBase(BaseEstimator):
                 self.operators.append(op_class)
                 self.arguments += arg_types
 
+        if self.max_time_mins is None and self.generations is None:
+            raise ValueError("Either the parameter generations should bet set or a maximum evaluation time should be defined via max_time_mins")
+
         # Schedule TPOT to run for many generations if the user specifies a
-        # run-time limit TPOT will automatically interrupt itself when the timer
-        # runs out
+        # run-time limit TPOT will automatically interrupt itself when the timer runs out
         if self.max_time_mins is not None and self.generations is None :
             self.generations = 1000000
 
@@ -1261,7 +1263,7 @@ class TPOTBase(BaseEstimator):
         if self.max_time_mins:
             total_mins_elapsed = (datetime.now() - self._start_datetime).total_seconds() / 60.
             if total_mins_elapsed >= self.max_time_mins:
-                raise KeyboardInterrupt('{} minutes have elapsed. TPOT will close down.'.format(total_mins_elapsed))
+                raise KeyboardInterrupt('{:.2f} minutes have elapsed. TPOT will close down.'.format(total_mins_elapsed))
 
     def _combine_individual_stats(self, operator_count, cv_score, individual_stats):
         """Combine the stats with operator count and cv score and preprare to be written to _evaluated_individuals

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -569,7 +569,7 @@ class TPOTBase(BaseEstimator):
         # Schedule TPOT to run for many generations if the user specifies a
         # run-time limit TPOT will automatically interrupt itself when the timer
         # runs out
-        if self.max_time_mins is not None:
+        if self.max_time_mins is not None and self.generations is None :
             self.generations = 1000000
 
         # Prompt the user if their version is out of date


### PR DESCRIPTION
Thix PR solves #936 by allowing to independently use generations and max_time_mins to limit the tpot search through using one of the parameters or both.