### PR TITLE
check time usage before pipeline evaluation #966

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1285,7 +1285,10 @@ class TPOTBase(BaseEstimator):
         )
 
         result_score_list = []
+
         try:
+            # check time limit before pipeline evaluation
+            self._stop_by_max_time_mins()
             # Don't use parallelization if n_jobs==1
             if self._n_jobs == 1 and not self.use_dask:
                 for sklearn_pipeline in sklearn_pipeline_list:


### PR DESCRIPTION
This is a patch for fixing issue mentioned in #966.

# How to test in your environment
For testing this PR, you may install the PR into a test environment via:

```shell
pip install --upgrade --no-deps --force-reinstall git+https://github.com/weixuanfu/tpot.git@issue_996
```
Or if the PR is merged, you may install the patch into the test environment via:

```shell
pip install --upgrade --no-deps --force-reinstall git+https://github.com/EpistasisLab/tpot.git@development
```

# Demo for testing the PR:

```python
from tpot import TPOTClassifier
from sklearn.datasets import load_digits
from sklearn.model_selection import train_test_split

digits = load_digits()
X_train, X_test, y_train, y_test = train_test_split(digits.data, digits.target,
                                                    train_size=0.75, test_size=0.25, random_state=42)

# create a very limited search space. 
tpot_config = {
    'sklearn.naive_bayes.GaussianNB': {
    },

    'sklearn.naive_bayes.BernoulliNB': {
        'alpha': [1e-3, 1e-2, 1e-1, 1., 10., 100.],
        'fit_prior': [True, False]
    },

    'sklearn.naive_bayes.MultinomialNB': {
        'alpha': [1e-3, 1e-2, 1e-1, 1., 10., 100.],
        'fit_prior': [True, False]
    }
}

tpot = TPOTClassifier(generations=500, population_size=100, verbosity=2,
                      config_dict=tpot_config, max_time_mins=1, random_state=42)
tpot.fit(X_train, y_train)
print(tpot.score(X_test, y_test))
```

# Expected results from the demo:
```shell
Generation 1 - Current best internal CV score: 0.9019815068650034
Generation 2 - Current best internal CV score: 0.902060642329434
Generation 3 - Current best internal CV score: 0.9028097059998459
Generation 4 - Current best internal CV score: 0.9028097059998459
Generation 5 - Current best internal CV score: 0.9028097059998459
Generation 6 - Current best internal CV score: 0.9028097059998459
Generation 7 - Current best internal CV score: 0.9028097059998459
Generation 8 - Current best internal CV score: 0.9028097059998459
Generation 9 - Current best internal CV score: 0.9028097059998459
Generation 10 - Current best internal CV score: 0.9028097059998459
Generation 11 - Current best internal CV score: 0.9028097059998459
Generation 12 - Current best internal CV score: 0.9028097059998459
Generation 13 - Current best internal CV score: 0.9028097059998459
Generation 14 - Current best internal CV score: 0.9028097059998459
Generation 15 - Current best internal CV score: 0.9028097059998459
Generation 16 - Current best internal CV score: 0.9028097059998459
Generation 17 - Current best internal CV score: 0.9028097059998459
Generation 18 - Current best internal CV score: 0.9028097059998459

1.01 minutes have elapsed. TPOT will close down.
TPOT closed during evaluation in one generation.
WARNING: TPOT may not provide a good pipeline if TPOT is stopped/interrupted in a early generation.


TPOT closed prematurely. Will use the current best pipeline.

Best pipeline: GaussianNB(GaussianNB(MultinomialNB(input_matrix, alpha=1.0, fit_prior=False)))
0.9155555555555556

```