### PR TITLE
Fix compatibility issue with scikit-learn v0.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,6 @@ matrix:
     env: PYTHON_VERSION="3.7"  COVERAGE="true"  DASK_ML_VERSION="1.0.0"
     before_install:
       - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - name: "Python 3.7 on macOS"
-    os: osx
-    osx_image: xcode10.2  # Python 3.7.2 running on macOS 10.14.3
-    language: shell       # 'language: python' is an error on Travis CI macOS
-    env: PYTHON_VERSION="3.7"  DASK_ML_VERSION="1.0.0"
-    before_install:
-      - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
 install: source ./ci/.travis_install.sh
 script: bash ./ci/.travis_test.sh
 after_success:

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,3 +1,3 @@
-xgboost==0.6a2
+xgboost==0.90
 scikit-mdr==0.4.4
 skrebate==0.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 deap>=1.2
 nose==1.3.7
 numpy>=1.16.3
-scikit-learn>=0.21.0
+scikit-learn>=0.22.0
 scipy>=1.3.1
 tqdm>=4.36.1
 update-checker>=0.16
-stopit>=1.1.1
+stopit>=1.1.2
 pandas>=0.24.2
 joblib>=0.13.2

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ This project is hosted at https://github.com/EpistasisLab/tpot
     zip_safe=True,
     install_requires=['numpy>=1.16.3',
                     'scipy>=1.3.1',
-                    'scikit-learn>=0.21.0',
+                    'scikit-learn>=0.22.0',
                     'deap>=1.2',
                     'update_checker>=0.16',
                     'tqdm>=4.36.1',

--- a/tests/stacking_estimator_tests.py
+++ b/tests/stacking_estimator_tests.py
@@ -78,7 +78,7 @@ def test_StackingEstimator_3():
 
     # test cv score
     cv_score = np.mean(cross_val_score(sklearn_pipeline, training_features, training_target, cv=3, scoring='accuracy'))
-    known_cv_score = 0.9472823753147593
+    known_cv_score = 0.9643652561247217
 
     assert np.allclose(known_cv_score, cv_score)
 
@@ -101,6 +101,6 @@ def test_StackingEstimator_4():
 
     # test cv score
     cv_score = np.mean(cross_val_score(sklearn_pipeline, training_features_r, training_target_r, cv=3, scoring='r2'))
-    known_cv_score = 0.7989564328211737
+    known_cv_score = 0.8216045257587923
 
     assert np.allclose(known_cv_score, cv_score)

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -58,7 +58,7 @@ from sklearn.model_selection import train_test_split, cross_val_score, GroupKFol
 from joblib import Memory
 from sklearn.metrics import make_scorer, roc_auc_score
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, TransformerMixin
-from sklearn.feature_selection.base import SelectorMixin
+from sklearn.feature_selection._base import SelectorMixin
 from deap import creator, gp
 from deap.tools import ParetoFront
 from nose.tools import nottest, assert_raises, assert_not_equal, assert_greater_equal, assert_equal, assert_in
@@ -1426,7 +1426,15 @@ def test_evaluate_individuals():
         sklearn_pipeline = tpot_obj._toolbox.compile(expr=deap_pipeline)
 
         try:
-            cv_scores = cross_val_score(sklearn_pipeline, training_features, training_target, cv=5, scoring='accuracy', verbose=0)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                cv_scores = cross_val_score(sklearn_pipeline,
+                                            training_features,
+                                            training_target,
+                                            cv=5,
+                                            scoring='accuracy',
+                                            verbose=0,
+                                            error_score='raise')
             mean_cv_scores = np.mean(cv_scores)
         except Exception as e:
             mean_cv_scores = -float('inf')
@@ -1460,7 +1468,15 @@ def test_evaluate_individuals_2():
         sklearn_pipeline = tpot_obj._toolbox.compile(expr=deap_pipeline)
 
         try:
-            cv_scores = cross_val_score(sklearn_pipeline, training_features, training_target, cv=5, scoring='accuracy', verbose=0)
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                cv_scores = cross_val_score(sklearn_pipeline,
+                                            training_features,
+                                            training_target,
+                                            cv=5,
+                                            scoring='accuracy',
+                                            verbose=0,
+                                            error_score='raise')
             mean_cv_scores = np.mean(cv_scores)
         except Exception as e:
             mean_cv_scores = -float('inf')

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -58,7 +58,10 @@ from sklearn.model_selection import train_test_split, cross_val_score, GroupKFol
 from joblib import Memory
 from sklearn.metrics import make_scorer, roc_auc_score
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, TransformerMixin
-from sklearn.feature_selection._base import SelectorMixin
+try:
+    from sklearn.feature_selection._base import SelectorMixin
+except ImportError:
+    from sklearn.feature_selection.base import SelectorMixin
 from deap import creator, gp
 from deap.tools import ParetoFront
 from nose.tools import nottest, assert_raises, assert_not_equal, assert_greater_equal, assert_equal, assert_in

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -52,7 +52,6 @@ from sklearn.pipeline import make_pipeline, make_union
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.model_selection import train_test_split
-from sklearn.metrics.scorer import _BaseScorer
 
 from joblib import Parallel, delayed, Memory
 
@@ -304,7 +303,7 @@ class TPOTBase(BaseEstimator):
                 args_list = inspect.getfullargspec(scoring)[0]
                 if args_list == ["y_true", "y_pred"] or (hasattr(module, 'startswith') and \
                     (module.startswith('sklearn.metrics.') or module.startswith('tpot.metrics')) and \
-                    not module.startswith('sklearn.metrics.scorer') and \
+                    not module.startswith('sklearn.metrics._scorer') and \
                     not module.startswith('sklearn.metrics.tests.')):
                     raise ValueError(
                             'Scoring function {} looks like it is a metric function '

--- a/tpot/builtins/feature_set_selector.py
+++ b/tpot/builtins/feature_set_selector.py
@@ -25,8 +25,7 @@ import numpy as np
 import pandas as pd
 import os, os.path
 from sklearn.base import BaseEstimator
-from sklearn.feature_selection.base import SelectorMixin
-from sklearn.utils.validation import check_is_fitted
+from sklearn.feature_selection._base import SelectorMixin
 
 
 class FeatureSetSelector(BaseEstimator, SelectorMixin):
@@ -142,7 +141,7 @@ class FeatureSetSelector(BaseEstimator, SelectorMixin):
             An element is True iff its corresponding feature is selected for
             retention.
         """
-        check_is_fitted(self, 'feat_list_idx')
+
         n_features = len(self.feature_names)
         mask = np.zeros(n_features, dtype=bool)
         mask[np.asarray(self.feat_list_idx)] = True

--- a/tpot/builtins/feature_set_selector.py
+++ b/tpot/builtins/feature_set_selector.py
@@ -25,7 +25,10 @@ import numpy as np
 import pandas as pd
 import os, os.path
 from sklearn.base import BaseEstimator
-from sklearn.feature_selection._base import SelectorMixin
+try:
+    from sklearn.feature_selection._base import SelectorMixin
+except ImportError:
+    from sklearn.feature_selection.base import SelectorMixin
 
 
 class FeatureSetSelector(BaseEstimator, SelectorMixin):

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -28,7 +28,7 @@ from deap import tools, gp
 from inspect import isclass
 from .operator_utils import set_sample_weight
 from sklearn.utils import indexable
-from sklearn.metrics.scorer import check_scoring
+from sklearn.metrics import check_scoring
 from sklearn.model_selection._validation import _fit_and_score
 from sklearn.model_selection._split import check_cv
 
@@ -456,10 +456,11 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
                                          test=test,
                                          verbose=0,
                                          parameters=None,
+                                         error_score='raise',
                                          fit_params=sample_weight_dict)
                                     for train, test in cv_iter]
-                CV_score = np.array(scores)[:, 0]
-                return np.nanmean(CV_score)
+            CV_score = np.array(scores)[:, 0]
+            return np.nanmean(CV_score)
         except TimeoutException:
             return "Timeout"
         except Exception as e:

--- a/tpot/operator_utils.py
+++ b/tpot/operator_utils.py
@@ -25,7 +25,10 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, TransformerMixin
-from sklearn.feature_selection._base import SelectorMixin
+try:
+    from sklearn.feature_selection._base import SelectorMixin
+except ImportError:
+    from sklearn.feature_selection.base import SelectorMixin
 import inspect
 
 

--- a/tpot/operator_utils.py
+++ b/tpot/operator_utils.py
@@ -25,7 +25,7 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, TransformerMixin
-from sklearn.feature_selection.base import SelectorMixin
+from sklearn.feature_selection._base import SelectorMixin
 import inspect
 
 


### PR DESCRIPTION
Related to issue #981 #985 
Note for this PR: Some scoring and feature selection APIs were updated in scikit-learn v0.22 without compatibility with previous versions of scikit-learn. So the future version of TPOT should require scikit-learn >= 0.22.