### PR TITLE
More user friendly error message

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -792,10 +792,11 @@ class TPOTBase(BaseEstimator):
             if not self._optimized_pipeline:
                 raise RuntimeError('There was an error in the TPOT optimization '
                                    'process. This could be because the data was '
-                                   'not formatted properly, or because data for '
+                                   'not formatted properly, because data for '
                                    'a regression problem was provided to the '
-                                   'TPOTClassifier object. Please make sure you '
-                                   'passed the data to TPOT correctly.')
+                                   'TPOTClassifier object, or an error in a '
+                                   'custom scoring function. Please make sure '
+                                   'you passed the data to TPOT correctly.')
             else:
                 pareto_front_wvalues = [pipeline_scores.wvalues[1] for pipeline_scores in self._pareto_front.keys]
                 if not self._last_optimized_pareto_front:


### PR DESCRIPTION
Make an error message more user friendly for people who have errors in their custom scoring functions.

## What does this PR do?

Give the user another hint as to what may have caused an error.

## Where should the reviewer start?

Look at the diff

## How should this PR be tested?

Standard tests

## Any background context you want to provide?

#983 

It would be nice to have an debugging option to make `tpot.gp_deap:_wrapped_cross_val_score()` print exceptions rather than hiding all exception. It would probably be best to control that via by the verbosity setting, but a separate hacky flag like `tpot.gp_deap.display_exceptions=True` would be adequate for local debugging purposes. 

## What are the relevant issues?

#983 

## Screenshots (if appropriate)



## Questions:

- Do the docs need to be updated?
No
- Does this PR add new (Python) dependencies?
No