### PR TITLE
Bugfix stratify pretest sample

### DIFF
--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -1667,6 +1667,24 @@ def test_preprocess_individuals_3():
                                 tpot_obj._preprocess_individuals(individuals)
         assert tpot_obj._pbar.total == 6
 
+def test__init_pretest():
+    """Assert that the init_pretest function produces a sample with all labels"""
+    tpot_obj = TPOTClassifier(
+        random_state=42,
+        population_size=1,
+        offspring_size=2,
+        generations=1,
+        verbosity=0,
+        config_dict='TPOT light'
+    )
+    tpot_obj._fit_init()
+
+    np.random.seed(seed=42)
+    features = np.random.rand(10000,2)
+    target = np.random.binomial(1,0.01,(10000,1))
+
+    tpot_obj._init_pretest(features, target)
+    assert(np.unique(tpot_obj.pretest_y).size == np.unique(target).size)
 
 def test_check_dataset():
     """Assert that the check_dataset function returns feature and target as expected."""

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -585,12 +585,9 @@ class TPOTBase(BaseEstimator):
 
     def _init_pretest(self, features,target):
         """Set the sample of data used to verify pipelines work with the passed data set
-
-        Use a 
+ 
         """
-        self.pretest_X, _, self.pretest_y, _ = train_test_split(features,
-                                                target, train_size=min(50, int(0.9*features.shape[0])),
-                                                test_size=None, random_state=self.random_state)
+        raise NotImplemented("Use TPOTClassifier or TPOTRegressor")
 
     def fit(self, features, target, sample_weight=None, groups=None):
         """Fit an optimized machine learning pipeline.

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -583,6 +583,14 @@ class TPOTBase(BaseEstimator):
         else:
             self._n_jobs = self.n_jobs
 
+    def _init_pretest(self, features,target):
+        """Set the sample of data used to verify pipelines work with the passed data set
+
+        Use a 
+        """
+        self.pretest_X, _, self.pretest_y, _ = train_test_split(features,
+                                                target, train_size=min(50, int(0.9*features.shape[0])),
+                                                test_size=None, random_state=self.random_state)
 
     def fit(self, features, target, sample_weight=None, groups=None):
         """Fit an optimized machine learning pipeline.
@@ -625,10 +633,7 @@ class TPOTBase(BaseEstimator):
         self._fit_init()
         features, target = self._check_dataset(features, target, sample_weight)
 
-
-        self.pretest_X, _, self.pretest_y, _ = train_test_split(features,
-                                                target, train_size=min(50, int(0.9*features.shape[0])),
-                                                test_size=None, random_state=self.random_state)
+        self._init_pretest(features, target)
 
         # Randomly collect a subsample of training samples for pipeline optimization process.
         if self.subsample < 1.0:


### PR DESCRIPTION
## What does this PR do?

Fixes an edge case that arises when using tpot on dataset with extreme class imbalance where the pretest sample would cause an error to be thrown since the sample resulted in only one class being represented in the pretest_sample

## Where should the reviewer start?
See the changes in the tpot base with the introduction of a init_pretest function and the corresponding implementation in the TPotClassifier


## How should this PR be tested?
a unit test was added to verify that the pretest function works as intended


## Any background context you want to provide?
see PR description
## Questions:

- Do the docs need to be updated? no
- Does this PR add new (Python) dependencies? no
