### PR TITLE
DOC: add conda-forge install instructions

### DIFF
--- a/docs_sources/installing.md
+++ b/docs_sources/installing.md
@@ -20,6 +20,10 @@ TPOT is built on top of several existing Python libraries, including:
 
 Most of the necessary Python packages can be installed via the [Anaconda Python distribution](https://www.continuum.io/downloads), which we strongly recommend that you use. We also strongly recommend that you use of Python 3 over Python 2 if you're given the choice.
 
+You can install TPOP using `pip` or `conda-forge`.
+
+## Pip
+
 NumPy, SciPy, scikit-learn, pandas and joblib can be installed in Anaconda via the command:
 
 ```Shell
@@ -57,5 +61,21 @@ Finally to install TPOT itself, run the following command:
 ```Shell
 pip install tpot
 ```
+
+## conda-forge
+
+To install tpot and its core dependencies you can use:
+
+```Shell
+conda install -c conda-forge tpot
+```
+
+To install additional dependencies you can use:
+
+```Shell
+conda install -c conda-forge tpot xgboost dask dask-ml scikit-mdr skrebate
+```
+
+## Installation problems
 
 Please [file a new issue](https://github.com/EpistasisLab/tpot/issues/new) if you run into installation problems.

--- a/docs_sources/installing.md
+++ b/docs_sources/installing.md
@@ -22,7 +22,7 @@ Most of the necessary Python packages can be installed via the [Anaconda Python 
 
 You can install TPOP using `pip` or `conda-forge`.
 
-## Pip
+## pip
 
 NumPy, SciPy, scikit-learn, pandas and joblib can be installed in Anaconda via the command:
 


### PR DESCRIPTION
## What does this PR do?

Add conda-forge install instructions
 
## Where should the reviewer start?

#1005, #165  

## How should this PR be tested?

Ensure it looks pretty on the website.
Test the conda forge install

## Any background context you want to provide?

NA

## What are the relevant issues?

[you can link directly to issues by entering # then the number of the issue, for example, #3 links to issue 3]

## Screenshots (if appropriate)

<details>
```
(tpot) ray@ray-MS-7B43:~/Documents/PYTHON_dev/tpot/docs_sources$ conda install -c conda-forge tpot xgboost dask dask-ml scikit-mdr skrebate
Collecting package metadata (current_repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /home/ray/local/bin/anaconda3/envs/tpot

  added / updated specs:
    - dask
    - dask-ml
    - scikit-mdr
    - skrebate
    - tpot
    - xgboost


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    certifi-2019.11.28         |           py37_0         148 KB  conda-forge
    dask-ml-1.2.0              |             py_0          89 KB  conda-forge
    llvmlite-0.31.0            |   py37h8b12597_0         325 KB  conda-forge
    numba-0.47.0               |   py37hb3f55d8_0         3.4 MB  conda-forge
    scikit-mdr-0.4.4           |             py_0          11 KB  conda-forge
    skrebate-0.6               |             py_0          19 KB  conda-forge
    ------------------------------------------------------------
                                           Total:         4.0 MB

The following NEW packages will be INSTALLED:

  _py-xgboost-mutex  conda-forge/linux-64::_py-xgboost-mutex-2.0-cpu_0
  bokeh              conda-forge/linux-64::bokeh-1.4.0-py37_0
  cffi               conda-forge/linux-64::cffi-1.13.2-py37h8022711_0
  chardet            conda-forge/linux-64::chardet-3.0.4-py37_1003
  click              conda-forge/noarch::click-7.0-py_0
  cloudpickle        conda-forge/noarch::cloudpickle-1.2.2-py_1
  cryptography       conda-forge/linux-64::cryptography-2.8-py37h72c5cf5_1
  cycler             conda-forge/noarch::cycler-0.10.0-py_2
  cytoolz            conda-forge/linux-64::cytoolz-0.10.1-py37h516909a_0
  dask               conda-forge/noarch::dask-2.9.2-py_0
  dask-core          conda-forge/noarch::dask-core-2.9.2-py_0
  dask-glm           conda-forge/noarch::dask-glm-0.2.0-py_1
  dask-ml            conda-forge/noarch::dask-ml-1.2.0-py_0
  dbus               conda-forge/linux-64::dbus-1.13.6-he372182_0
  deap               conda-forge/linux-64::deap-1.3.0-py37hb3f55d8_0
  distributed        conda-forge/noarch::distributed-2.9.3-py_0
  expat              conda-forge/linux-64::expat-2.2.5-he1b5a44_1004
  fontconfig         conda-forge/linux-64::fontconfig-2.13.1-he4413a7_1000
  freetype           conda-forge/linux-64::freetype-2.10.0-he983fc9_1
  fsspec             conda-forge/noarch::fsspec-0.6.2-py_0
  gettext            conda-forge/linux-64::gettext-0.19.8.1-hc5be6a0_1002
  glib               conda-forge/linux-64::glib-2.58.3-py37h6f030ca_1002
  gst-plugins-base   conda-forge/linux-64::gst-plugins-base-1.14.5-h0935bb2_0
  gstreamer          conda-forge/linux-64::gstreamer-1.14.5-h36ae1b5_0
  heapdict           conda-forge/noarch::heapdict-1.0.1-py_0
  icu                conda-forge/linux-64::icu-58.2-hf484d3e_1000
  idna               conda-forge/linux-64::idna-2.8-py37_1000
  jinja2             conda-forge/noarch::jinja2-2.10.3-py_0
  joblib             conda-forge/noarch::joblib-0.14.1-py_0
  jpeg               conda-forge/linux-64::jpeg-9c-h14c3975_1001
  kiwisolver         conda-forge/linux-64::kiwisolver-1.1.0-py37hc9558a2_0
  libblas            conda-forge/linux-64::libblas-3.8.0-14_openblas
  libcblas           conda-forge/linux-64::libcblas-3.8.0-14_openblas
  libgfortran-ng     conda-forge/linux-64::libgfortran-ng-7.3.0-hdf63c60_4
  libiconv           conda-forge/linux-64::libiconv-1.15-h516909a_1005
  liblapack          conda-forge/linux-64::liblapack-3.8.0-14_openblas
  libllvm8           conda-forge/linux-64::libllvm8-8.0.1-hc9558a2_0
  libopenblas        conda-forge/linux-64::libopenblas-0.3.7-h5ec1e0e_6
  libpng             conda-forge/linux-64::libpng-1.6.37-hed695b0_0
  libtiff            conda-forge/linux-64::libtiff-4.1.0-hc3755c2_3
  libuuid            conda-forge/linux-64::libuuid-2.32.1-h14c3975_1000
  libxcb             conda-forge/linux-64::libxcb-1.13-h14c3975_1002
  libxgboost         conda-forge/linux-64::libxgboost-0.90-he1b5a44_4
  libxml2            pkgs/main/linux-64::libxml2-2.9.9-hea5a465_1
  llvmlite           conda-forge/linux-64::llvmlite-0.31.0-py37h8b12597_0
  locket             conda-forge/noarch::locket-0.2.0-py_2
  lz4-c              conda-forge/linux-64::lz4-c-1.8.3-he1b5a44_1001
  markupsafe         conda-forge/linux-64::markupsafe-1.1.1-py37h516909a_0
  matplotlib         pkgs/main/linux-64::matplotlib-3.1.1-py37h5429711_0
  msgpack-python     conda-forge/linux-64::msgpack-python-0.6.2-py37hc9558a2_0
  multipledispatch   conda-forge/noarch::multipledispatch-0.6.0-py_0
  numba              conda-forge/linux-64::numba-0.47.0-py37hb3f55d8_0
  numpy              conda-forge/linux-64::numpy-1.17.3-py37h95a1406_0
  olefile            conda-forge/noarch::olefile-0.46-py_0
  packaging          conda-forge/noarch::packaging-20.0-py_0
  pandas             conda-forge/linux-64::pandas-0.25.3-py37hb3f55d8_0
  partd              conda-forge/noarch::partd-1.1.0-py_0
  pcre               conda-forge/linux-64::pcre-8.43-he1b5a44_0
  pillow             pkgs/main/linux-64::pillow-7.0.0-py37hb39fc2d_0
  psutil             conda-forge/linux-64::psutil-5.6.7-py37h516909a_0
  pthread-stubs      conda-forge/linux-64::pthread-stubs-0.4-h14c3975_1001
  py-xgboost         conda-forge/linux-64::py-xgboost-0.90-py37_4
  pycparser          conda-forge/linux-64::pycparser-2.19-py37_1
  pyopenssl          conda-forge/linux-64::pyopenssl-19.1.0-py37_0
  pyparsing          conda-forge/noarch::pyparsing-2.4.6-py_0
  pyqt               conda-forge/linux-64::pyqt-5.9.2-py37hcca6a23_4
  pysocks            conda-forge/linux-64::pysocks-1.7.1-py37_0
  python-dateutil    conda-forge/noarch::python-dateutil-2.8.1-py_0
  pytz               conda-forge/noarch::pytz-2019.3-py_0
  pyyaml             conda-forge/linux-64::pyyaml-5.3-py37h516909a_0
  qt                 conda-forge/linux-64::qt-5.9.7-h52cfd70_2
  requests           conda-forge/linux-64::requests-2.22.0-py37_1
  scikit-learn       conda-forge/linux-64::scikit-learn-0.22.1-py37hcdab131_1
  scikit-mdr         conda-forge/noarch::scikit-mdr-0.4.4-py_0
  scipy              conda-forge/linux-64::scipy-1.4.1-py37h921218d_0
  sip                pkgs/main/linux-64::sip-4.19.8-py37hf484d3e_0
  six                conda-forge/linux-64::six-1.14.0-py37_0
  skrebate           conda-forge/noarch::skrebate-0.6-py_0
  sortedcontainers   conda-forge/noarch::sortedcontainers-2.1.0-py_0
  stopit             conda-forge/noarch::stopit-1.1.2-py_0
  tblib              conda-forge/noarch::tblib-1.6.0-py_0
  toolz              conda-forge/noarch::toolz-0.10.0-py_0
  tornado            conda-forge/linux-64::tornado-6.0.3-py37h516909a_0
  tpot               conda-forge/noarch::tpot-0.11.1-py_0
  tqdm               conda-forge/noarch::tqdm-4.41.1-py_0
  update_checker     conda-forge/noarch::update_checker-0.16-py_0
  urllib3            conda-forge/linux-64::urllib3-1.25.7-py37_0
  xgboost            conda-forge/linux-64::xgboost-0.90-py37he1b5a44_4
  xorg-libxau        conda-forge/linux-64::xorg-libxau-1.0.9-h14c3975_0
  xorg-libxdmcp      conda-forge/linux-64::xorg-libxdmcp-1.1.3-h516909a_0
  yaml               conda-forge/linux-64::yaml-0.2.2-h516909a_1
  zict               conda-forge/noarch::zict-1.0.0-py_0
  zstd               conda-forge/linux-64::zstd-1.4.4-h3b9ef0a_1


```
</details>

## Questions:

- Do the docs need to be updated?
- Does this PR add new (Python) dependencies?
