### PR TITLE
Fix `_pre_test` hanging when generating candidates

### DIFF
--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -53,7 +53,7 @@ def _pre_test(func):
         A wrapper function around the func parameter
     """
     @threading_timeoutable(default="timeout")
-    def safe_fit(func, *args):
+    def time_limited_call(func, *args):
         func(*args)
 
     @wraps(func)
@@ -94,7 +94,7 @@ def _pre_test(func):
                     sklearn_pipeline = eval(pipeline_code, self.operators_context)
                     with warnings.catch_warnings():
                         warnings.simplefilter('ignore')
-                        safe_fit(
+                        time_limited_call(
                             sklearn_pipeline.fit,
                             self.pretest_X,
                             self.pretest_y,


### PR DESCRIPTION

This PR addresses the issue #1023

We added a time out to the pipeline `.fit` call.

Running the below on the original codebase should hang, while the patched version should complete as expected.

```
> cat example.py

import tpot
import numpy as np
import pmlb

X, y = pmlb.fetch_data("Hill_Valley_without_noise", return_X_y=True)

clf = tpot.TPOTClassifier(
  max_time_mins=1,
  max_eval_time_mins=1,
  cv=2,
  config_dict={
      'sklearn.decomposition.SparsePCA':{},
      'sklearn.linear_model.LogisticRegression':{},
  },
  verbosity=3,
)

clf.fit(X, y)
```

```
timeout 5m python example.py
echo $?
```

Note that I chose a timeout of 2 seconds in the patch (an arbitrary choice). I leave the choice of this to the maintainers, who are likely to have a better sense of a reasonable value.

## Questions:

- Do the docs need to be updated?
No

- Does this PR add new (Python) dependencies?
No
