### PR TITLE
tests: Adjust some tolerances on non-amd64

### DIFF
--- a/tests/stacking_estimator_tests.py
+++ b/tests/stacking_estimator_tests.py
@@ -23,6 +23,8 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 """
 
+import platform
+
 import numpy as np
 from tpot.builtins import StackingEstimator
 from sklearn.linear_model import LogisticRegression, Lasso
@@ -103,4 +105,10 @@ def test_StackingEstimator_4():
     cv_score = np.mean(cross_val_score(sklearn_pipeline, training_features_r, training_target_r, cv=3, scoring='r2'))
     known_cv_score = 0.8216045257587923
 
-    assert np.allclose(known_cv_score, cv_score)
+    # On some non-amd64 systems such as arm64, a resulting score of
+    # 0.8207525232725118 was observed, so we need to add a tolerance there
+    if platform.machine() != 'x86_64':
+        assert np.allclose(known_cv_score, cv_score, rtol=0.01)
+    else:
+        assert np.allclose(known_cv_score, cv_score)
+

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -52,6 +52,7 @@ from datetime import datetime
 from time import sleep
 from tempfile import mkdtemp
 from shutil import rmtree
+import platform
 
 from sklearn.datasets import load_digits, load_boston, make_classification
 from sklearn.model_selection import train_test_split, cross_val_score, GroupKFold
@@ -573,7 +574,12 @@ def test_score_3():
 
     # Get score from TPOT
     score = tpot_obj.score(testing_features_r, testing_target_r)
-    assert np.allclose(known_score, score)
+    # On some non-amd64 systems such as arm64, a resulting score of
+    # 0.8207525232725118 was observed, so we need to add a tolerance there
+    if platform.machine() != 'amd64':
+        assert np.allclose(known_score, score, rtol=0.03)
+    else:
+        assert np.allclose(known_score, score)
 
 
 def test_sample_weight_func():
@@ -621,7 +627,12 @@ def test_sample_weight_func():
 
     assert np.allclose(cv_score1, cv_score2)
     assert not np.allclose(cv_score1, cv_score_weight)
-    assert np.allclose(known_score, score)
+    # On some non-amd64 systems such as arm64, a resulting score of
+    # 0.8207525232725118 was observed, so we need to add a tolerance there
+    if platform.machine() != 'amd64':
+        assert np.allclose(known_score, score, rtol=0.01)
+    else:
+        assert np.allclose(known_score, score)
 
 
 def test_template_1():


### PR DESCRIPTION
This adjusts the relative tolerances of three tests on non-amd64 platforms,
where they otherwise fail, by 1% to 3%.

Resolves #1047.