### PR TITLE
Fix early_stop param does not work properly

### DIFF
--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -230,9 +230,6 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
 
     # Begin the generational process
     for gen in range(1, ngen + 1):
-        # after each population save a periodic pipeline
-        if per_generation_function is not None:
-            per_generation_function(gen)
         # Vary the population
         offspring = varOr(population, toolbox, lambda_, cxpb, mutpb)
 


### PR DESCRIPTION
The `per_generation_function` is called twice so that `_last_optimized_pareto_front_n_gens` is double counted, which causes TPOT stops the process in half time (`early_step`/2)