### PR TITLE
Write generation info to log_file in high verbosity mode

### DIFF
--- a/tests/test_log_file.py
+++ b/tests/test_log_file.py
@@ -25,21 +25,25 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 from tpot import TPOTClassifier
 from sklearn.datasets import load_iris
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_true
 import os
+import re
 
 data = load_iris()
 X = data['data']
 y = data['target']
+
+POP_SIZE = 2
+GEN_SIZE = 2
 
 def test_log_file_verbosity_1():
   """ Set verbosity as 1. Assert log_file parameter to generate log file. """
   file_name = "progress_verbose_1.log"
   tracking_progress_file = open(file_name, "w")
   tpot_obj = TPOTClassifier(
-                population_size=10,
-                generations=10,
-                verbosity=1, 
+                population_size=POP_SIZE,
+                generations=GEN_SIZE,
+                verbosity=1,
                 log_file=tracking_progress_file
             )
   tpot_obj.fit(X, y)
@@ -50,23 +54,32 @@ def test_log_file_verbosity_2():
   file_name = "progress_verbose_2.log"
   tracking_progress_file = open(file_name, "w")
   tpot_obj = TPOTClassifier(
-                population_size=10,
-                generations=10,
-                verbosity=2, 
+                population_size=POP_SIZE,
+                generations=GEN_SIZE,
+                verbosity=2,
                 log_file=tracking_progress_file
             )
   tpot_obj.fit(X, y)
   assert_equal(os.path.getsize(file_name) > 0,  True)
+  check_generations(file_name, GEN_SIZE)
 
 def test_log_file_verbose_3():
   """ Set verbosity as 3. Assert log_file parameter to generate log file. """
   file_name = "progress_verbosity_3.log"
   tracking_progress_file = open(file_name, "w")
   tpot_obj = TPOTClassifier(
-                population_size=10,
-                generations=10,
-                verbosity=3, 
+                population_size=POP_SIZE,
+                generations=GEN_SIZE,
+                verbosity=3,
                 log_file=tracking_progress_file
             )
   tpot_obj.fit(X, y)
   assert_equal(os.path.getsize(file_name) > 0,  True)
+  check_generations(file_name, GEN_SIZE)
+
+def check_generations(file_name, generations):
+    """ Assert generation log message is present in log_file. """
+    with open(file_name, "r") as file:
+        file_text = file.read()
+    for gen in range(generations):
+        assert_true(re.search("Generation {0} - .+".format(gen+1), file_text))

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -253,19 +253,19 @@ def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
             # Print only the best individual fitness
             if verbose == 2:
                 high_score = max(halloffame.keys[x].wvalues[1] for x in range(len(halloffame.keys)))
-                pbar.write('Generation {0} - Current best internal CV score: {1}'.format(gen, high_score))
+                pbar.fp.write('Generation {0} - Current best internal CV score: {1}'.format(gen, high_score))
 
             # Print the entire Pareto front
             elif verbose == 3:
-                pbar.write('Generation {} - Current Pareto front scores:'.format(gen))
+                pbar.fp.write('Generation {} - Current Pareto front scores:'.format(gen))
                 for pipeline, pipeline_scores in zip(halloffame.items, reversed(halloffame.keys)):
-                    pbar.write('{}\t{}\t{}'.format(
+                    pbar.fp.write('{}\t{}\t{}'.format(
                             int(pipeline_scores.wvalues[0]),
                             pipeline_scores.wvalues[1],
                             pipeline
                         )
                     )
-                pbar.write('')
+                pbar.fp.write('')
 
         # after each population save a periodic pipeline
         if per_generation_function is not None:


### PR DESCRIPTION
## What does this PR do?
Unsure that the log system also logs the generation informations to the log file when the later is provided.
Currently, the generation information are printed to the stdout even with a log_file 

## Where should the reviewer start?
- updates in gp_deap.py
- updates in test_log_file.py

## How should this PR be tested?
It uses the existing suite

## Any background context you want to provide?
I also reduced the number of generations and pop_size  in test_log_file.
The quality of the prediction is not important for the tests. Reducing the these parameters saves up some time on the tests.

## What are the relevant issues?
https://github.com/EpistasisLab/tpot/issues/1072


## Questions:

- Do the docs need to be updated? No
- Does this PR add new (Python) dependencies? No
