### PR TITLE
Make `torch` an optional dependency

### DIFF
--- a/docs_sources/installing.md
+++ b/docs_sources/installing.md
@@ -58,6 +58,10 @@ If you plan to use the [TPOT-MDR configuration](https://arxiv.org/abs/1702.01780
 pip install scikit-mdr skrebate
 ```
 
+To enable support for [PyTorch](https://pytorch.org/)-based neural networks (TPOT-NN), you will need to install PyTorch. TPOT-NN will work with either CPU or GPU PyTorch, but we strongly recommend using a GPU version, if possible, as CPU PyTorch models tend to train very slowly.
+
+We recommend following [PyTorch's installation instructions](https://pytorch.org/get-started/locally/) customized for your operating system and Python distribution.
+
 Finally to install TPOT itself, run the following command:
 
 ```Shell

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,3 +1,4 @@
 xgboost==0.90
 scikit-mdr==0.4.4
 skrebate==0.3.4
+torch==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ update-checker>=0.16
 stopit>=1.1.2
 pandas>=0.24.2
 joblib>=0.13.2
-torch==1.3.1

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ This project is hosted at https://github.com/EpistasisLab/tpot
         'dask': ['dask>=0.18.2',
                  'distributed>=1.22.1',
                  'dask-ml>=1.0.0'],
+        'torch': ['torch==1.3.1'],
     },
     classifiers=[
         'Intended Audience :: Science/Research',

--- a/tpot/builtins/__init__.py
+++ b/tpot/builtins/__init__.py
@@ -29,4 +29,8 @@ from .stacking_estimator import StackingEstimator
 from .one_hot_encoder import OneHotEncoder, auto_select_categorical_features, _transform_selected
 from .feature_transformers import CategoricalSelector, ContinuousSelector
 from .feature_set_selector import FeatureSetSelector
-from .nn import PytorchLRClassifier, PytorchMLPClassifier
+try:
+    from .nn import PytorchLRClassifier, PytorchMLPClassifier
+except (ModuleNotFoundError, ImportError):
+    import warnings
+    warnings.warn("Warning: `torch` not available - skipping import of NN models.")

--- a/tpot/builtins/nn.py
+++ b/tpot/builtins/nn.py
@@ -39,11 +39,15 @@ from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils.validation import check_X_y, assert_all_finite, check_array, check_is_fitted
 from sklearn.utils.multiclass import type_of_target
 
-import torch
-from torch import nn
-from torch.autograd import Variable
-from torch.optim import Adam
-from torch.utils.data import TensorDataset, DataLoader
+try:
+    import torch
+    from torch import nn
+    from torch.autograd import Variable
+    from torch.optim import Adam
+    from torch.utils.data import TensorDataset, DataLoader
+except ModuleNotFoundError:
+    print("Error importing NN models - optional dependency `torch` is not available.")
+    raise
 
 def _pytorch_model_is_fully_initialized(clf: BaseEstimator):
     if all([


### PR DESCRIPTION
## What does this PR do?
Fixed #1075 by making PyTorch an optional dependency. TPOT will only load NN modules if `torch` is available to import. If the user tries to directly import TPOT-NN estimators (e.g., `from tpot.builtins import nn`) without PyTorch installed, an appropriate error message will be raised.

## How should this PR be tested?

`nosetests -s -v --with-coverage`

## Any background context you want to provide?

n/a

## What are the relevant issues?

#1075 

## Screenshots (if appropriate)

n/a

## Questions:

- Do the docs need to be updated?
Yes, new information added to installation instruction Markdown source.
- Does this PR add new (Python) dependencies?
No, a dependency was removed.