### PR TITLE
Ignore npnanmean runtimewarning

### DIFF
--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -447,7 +447,7 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
     else:
         try:
             with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
+                warnings.simplefilter('ignore', category=RuntimeWarning)
                 scores = [_fit_and_score(estimator=clone(sklearn_pipeline),
                                          X=features,
                                          y=target,

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -447,7 +447,7 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
     else:
         try:
             with warnings.catch_warnings():
-                warnings.simplefilter('ignore', category=RuntimeWarning)
+                warnings.simplefilter('ignore')
                 scores = [_fit_and_score(estimator=clone(sklearn_pipeline),
                                          X=features,
                                          y=target,
@@ -459,8 +459,9 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
                                          error_score='raise',
                                          fit_params=sample_weight_dict)
                                     for train, test in cv_iter]
-            CV_score = np.array(scores)[:, 0]
-            return np.nanmean(CV_score)
+                CV_score = np.array(scores)[:, 0]
+                CV_score_mean = np.nanmean(CV_score)
+            return CV_score_mean
         except TimeoutException:
             return "Timeout"
         except Exception as e:


### PR DESCRIPTION
The `np.nanmean` used for meaning the CV scores throws a `RuntimeWarning: Mean of empty slice` when the `CV_score` array consists of nothing else than `np.nan`. 

The error message gets in the way of the general progress output and it could be argued that [the error message is non-sensical to start with](https://stackoverflow.com/questions/29688168/mean-nanmean-and-warning-mean-of-empty-slice).

I believe the `warnings.catch_warnings()` is implemented here for exactly that reason: to suppress these warnings. The last `return` line however also can throw this error and should therefore be indented as well.