### PR TITLE
Enable multiclass support for TPOT-NN

### DIFF
--- a/tpot/builtins/nn.py
+++ b/tpot/builtins/nn.py
@@ -162,8 +162,8 @@ class PytorchClassifier(PytorchEstimator, ClassifierMixin):
 
         assert_all_finite(X, y)
 
-        if type_of_target(y) != 'binary':
-            raise ValueError("Non-binary targets not supported")
+        #if type_of_target(y) != 'binary':
+        #    raise ValueError("Non-binary targets not supported")
 
         if np.any(np.iscomplex(X)) or np.any(np.iscomplex(y)):
             raise ValueError("Complex data not supported")

--- a/tpot/builtins/nn.py
+++ b/tpot/builtins/nn.py
@@ -154,16 +154,12 @@ class PytorchClassifier(PytorchEstimator, ClassifierMixin):
     def validate_inputs(self, X, y):
         # Things we don't want to allow until we've tested them:
         # - Sparse inputs
-        # - Multiclass outputs (e.g., more than 2 classes in `y`)
         # - Non-finite inputs
         # - Complex inputs
 
         X, y = check_X_y(X, y, accept_sparse=False, allow_nd=False)
 
         assert_all_finite(X, y)
-
-        #if type_of_target(y) != 'binary':
-        #    raise ValueError("Non-binary targets not supported")
 
         if np.any(np.iscomplex(X)) or np.any(np.iscomplex(y)):
             raise ValueError("Complex data not supported")


### PR DESCRIPTION
## What does this PR do?

Disables the requirement for binary output classes in TPOT-NN. Resolves #1149.


## Where should the reviewer start?

Check `tpot/builtins/nn.py` and make sure the standard TPOT tests still pass.


## How should this PR be tested?

Test against the standard nosetests suite and see if anything fails. There is currently a test for TPOT-NN specifically to ensure that multiclass problems are NOT supported that will fail as this PR disables that check; this can likely be modified to test that all estimators support multiclass problems. 

Multiclass problems where the set of output classes does not exist in a sequence beginning from 0 will still fail - for example, a problem with classes [0, 2, 3, 5, 6] will fail due to not having class 1 and 4, and a problem with classes [1, 2, 3] will fail due to not having class 0. This will likely need to be addressed in a future PR. 

The following code should test the multiclass functionality of the NN MLP classifier using TPOT's dependencies:

```
from tpot import TPOTClassifier
from sklearn.datasets import load_iris
from sklearn.model_selection import train_test_split


if(__name__ == "__main__"):

	iris = load_iris()
	X_train, X_test, y_train, y_test = train_test_split(iris.data, iris.target, train_size=0.75, test_size=0.25)

	nn_classifier = TPOTClassifier(config_dict='TPOT NN', template='Selector-Transformer-PytorchMLPClassifier', 
		generations=3, population_size=3)

	nn_classifier.fit(X_train, y_train)
	print(nn_classifier.score(X_test, y_test))

	nn_classifier.export('pipeline_nn_iris_norestriction.py')
```


## Any background context you want to provide?

This addresses #1149. Multiclass support was tested and validated using a variety of standard multiclass datasets, with no notable score degradation from base TPOT on multiclass problems. 


## What are the relevant issues?

#1149 


## Screenshots (if appropriate)



## Questions:

- Do the docs need to be updated? No, but adding an example of using TPOT-NN for multiclass classification may be helpful.
- Does this PR add new (Python) dependencies? No.
