### PR TITLE
Remove test checking that TPOT-NN errors for multiclass input

### DIFF
--- a/tests/nn_tests.py
+++ b/tests/nn_tests.py
@@ -59,17 +59,6 @@ def test_nn_conf_dict():
     clf = TPOTClassifier(config_dict=classifier_config_nn)
     assert clf.config_dict == classifier_config_nn
 
-def test_nn_errors_on_multiclass():
-    """Assert that TPOT-NN throws an error when you try to pass training data with > 2 classes. (NN)"""
-    clf = TPOTClassifier(
-        random_state=42,
-        population_size=1,
-        generations=1,
-        config_dict=classifier_config_nn,
-        template='PytorchLRClassifier'
-    )
-    assert_raises(ValueError, clf.fit, multiclass_X, multiclass_y)
-
 def test_pytorch_lr_classifier():
     """Assert that the PytorchLRClassifier model works. (NN)"""
     clf = nn.PytorchLRClassifier(


### PR DESCRIPTION
## What does this PR do?

Removes or corrects tests erroring due to PR #1175 as they are defunct.


## Where should the reviewer start?

Check `tests/nn_tests.py`


## How should this PR be tested?

Check that all other tests pass besides the one removed.


## Any background context you want to provide?

One test may still fail without further changes - one of the known_score tests (which may be due to scikit-learn updates). Left this one as a draft until that has been corrected, though this is an NN-specific change.


## What are the relevant issues?

N/A


## Screenshots (if appropriate)

N/A


## Questions:

- Do the docs need to be updated? No.
- Does this PR add new (Python) dependencies? No.
