### PR TITLE
Fix tests that fail due to changes in sklearn 0.24.0

### DIFF
--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -59,6 +59,7 @@ from tempfile import mkdtemp
 from shutil import rmtree
 import platform
 
+import sklearn
 from sklearn.datasets import load_digits, load_boston, make_classification, make_regression
 from sklearn import model_selection
 from joblib import Memory
@@ -625,7 +626,21 @@ def test_score_2():
     """Assert that the TPOTClassifier score function outputs a known score for a fixed pipeline."""
     tpot_obj = TPOTClassifier(random_state=34)
     tpot_obj._fit_init(training_features.shape)
-    known_score = 0.977777777778  # Assumes use of the TPOT accuracy function
+    #Score changes between sklearn versions; dictionary for different versions
+    #Up to date as of sklearn 0.24.2
+    score_dict = {
+        '0.24.2': 0.9755555555555555,
+        '0.24.1': 0.9755555555555555,
+        '0.24.0': 0.9755555555555555, #introduced a change affecting KNeighborsClassifier: https://github.com/scikit-learn/scikit-learn/pull/17038
+        '0.23.2': 0.977777777778,
+        '0.23.1': 0.977777777778,
+        '0.23.0': 0.977777777778,
+        '0.22.2': 0.977777777778,
+        '0.22.1': 0.977777777778,
+        '0.22': 0.977777777778,
+
+    }
+    # Scores assume use of the TPOT accuracy function
 
     # Create a pipeline with a known score
     pipeline_string = (
@@ -642,14 +657,34 @@ def test_score_2():
     # Get score from TPOT
     score = tpot_obj.score(testing_features, testing_target)
 
-    assert np.allclose(known_score, score)
+    if sklearn.__version__ in score_dict.keys():
+        known_score = score_dict[sklearn.__version__]
+        assert np.allclose(known_score, score)
+    else:
+        #If the version isn't found, compare to all versions in the dict
+        closeness = [np.allclose(score, known_score) for known_score in score_dict.values()]
+        assert(closeness)
 
 
 def test_score_3():
     """Assert that the TPOTRegressor score function outputs a known score for a fixed pipeline."""
     tpot_obj = TPOTRegressor(scoring='neg_mean_squared_error', random_state=72)
     tpot_obj._fit_init(training_features.shape)
-    known_score = -11.708199875921563
+    #Score changes between sklearn versions; dictionary for different versions
+    #Up to date as of sklearn 0.24.2
+    score_dict = {
+        '0.24.2': -11.708199875921563,
+        '0.24.1': -11.708199875921563,
+        '0.24.0': -11.708199875921563,
+        '0.23.2': -11.708199875921563,
+        '0.23.1': -11.708199875921563,
+        '0.23.0': -11.708199875921563,
+        '0.22.2': -11.708199875921563,
+        '0.22.1': -11.708199875921563,
+        '0.22': -11.708199875921563,
+
+    }
+    # Scores assume use of the TPOT accuracy function
 
     # Reify pipeline with known score
     pipeline_string = (
@@ -670,7 +705,13 @@ def test_score_3():
     # Get score from TPOT
     score = tpot_obj.score(testing_features_r, testing_target_r)
 
-    assert np.allclose(known_score, score, rtol=0.03)
+    if sklearn.__version__ in score_dict.keys():
+        known_score = score_dict[sklearn.__version__]
+        assert np.allclose(known_score, score)
+    else:
+        #If the version isn't found, compare to all versions in the dict
+        closeness = [np.allclose(score, known_score) for known_score in score_dict.values()]
+        assert(closeness)
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the test (`test_score_2` in `tpot_tests.py`) that was erroring on versions of sklearn >= 0.24.0 by adding a dictionary of scores for different sklearn versions. This was also done for test_score_3 - though that test didn't fail, the same method was implemented to make it easier to address the possibility of sklearn updates causing it to fail in the future. Versions from 0.22.0 onwards were included in the dict as this is the minimum version TPOT currently requires.


## Where should the reviewer start?

Review `tests/tpot_tests.py` to see the changes made. No other changes were made in this PR.


## How should this PR be tested?

Run the nosetests using TPOT on multiple versions of sklearn (all major releases between 0.22 and 0.24.2 were tested and included) and confirm that they all pass as expected.


## Any background context you want to provide?

sklearn 0.24.0 introduced a change to KNeighborsClassifier (https://github.com/scikit-learn/scikit-learn/pull/17038) that started causing the TPOT test for the known score of a pipeline including this classifier to fail. To make it easier to address this in the future while also supporting multiple versions of sklearn (rather than just the most recent), it would be useful if TPOT would check which sklearn version to use a known score from.

#1161 fixes a different test that was failing for similar reasons (changes in sklearn 0.24.0 moving an import).


## What are the relevant issues?

This is one of the tests that #1175 (and many other PRs since) have failed despite making no changes to the functionality implemented by these functions. 

The other failing test (due to an import in `one_hot_encoder.py` was previously addressed with #1161). 


## Screenshots (if appropriate)

N/A


## Questions:

- Do the docs need to be updated? No; nothing user-facing is changed. Only developers will be affected. 
- Does this PR add new (Python) dependencies? No.
