### PR TITLE
Fix use of dropped scikit-learn feature

### DIFF
--- a/tests/one_hot_encoder_tests.py
+++ b/tests/one_hot_encoder_tests.py
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
 import scipy.sparse
-from sklearn.utils.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal
 from sklearn.datasets import load_iris, load_boston
 from sklearn.linear_model import LinearRegression
 from sklearn.pipeline import make_pipeline


### PR DESCRIPTION
numpy.utils.testing was deprecated in 0.22 and dropped in 0.24. This causes some tests to fail.

Since all scikit-learn was doing was to import the relevant function `assert_array_almost_equal` from numpy, we can switch to import from numpy directly.
