### PR TITLE
Makes predict_proba consistent with other sklearn methods

### DIFF
--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -936,15 +936,16 @@ def test_predict_proba_2():
 
 
 def test_predict_proba_3():
-    """Assert that the TPOT predict_proba function raises a RuntimeError when no optimized pipeline exists."""
+    """Assert that the TPOT predict_proba function raises an AttributeError when no optimized pipeline exists."""
     tpot_obj = TPOTClassifier()
     tpot_obj._fit_init()
 
-    assert_raises(RuntimeError, tpot_obj.predict_proba, testing_features)
+    with assert_raises(AttributeError) as cm:
+        tpot_obj.predict_proba(testing_features)
 
 
 def test_predict_proba_4():
-    """Assert that the TPOT predict_proba function raises a RuntimeError when the optimized pipeline do not have the predict_proba() function"""
+    """Assert that the TPOT predict_proba function raises an AttributeError when the optimized pipeline do not have the predict_proba() function"""
     tpot_obj = TPOTRegressor()
     tpot_obj._fit_init()
     pipeline_string = (
@@ -957,7 +958,9 @@ def test_predict_proba_4():
     tpot_obj.fitted_pipeline_ = tpot_obj._toolbox.compile(expr=tpot_obj._optimized_pipeline)
     tpot_obj.fitted_pipeline_.fit(training_features_r, training_target_r)
 
-    assert_raises(RuntimeError, tpot_obj.predict_proba, testing_features)
+    with assert_raises(AttributeError) as cm:
+        tpot_obj.predict_proba(testing_features)
+    
 
 
 def test_predict_proba_5():

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -2468,24 +2468,3 @@ def test_clean_pipeline_string():
 
     pretty_string = tpot_obj.clean_pipeline_string(ind1)
     assert pretty_string == without_prefix
-
-def test_proba():
-    """Assert that TPOT's predict_proba is working correctly."""
-
-
-    X = np.random.rand(10,10)
-    y = np.random.randint(0,2,10)
-
-    est = TPOTClassifier(generations=1,population_size=1, template='LogisticRegression')
-    est.fit(X,y)
-    assert hasattr(est, "predict_proba") #This model has predict_proba
-    est.predict_proba(X)
-
-    est = TPOTClassifier(generations=1,population_size=1, template='LinearSVC')
-    with assert_raises(AttributeError) as cm: #This model is not fit and should raise an error
-        est.predict_proba(X)
-    est.fit(X,y)
-    assert not hasattr(est, "predict_proba") #This model does not have predict_proba, but it hasattr shouldn't raise an error
-    
-    with assert_raises(AttributeError) as cm: #This model does not have predict_proba so this should raise an error
-        est.predict_proba(X)

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -23,7 +23,6 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 """
 
-from errno import ESRMNT
 from tpot import TPOTClassifier, TPOTRegressor
 from tpot.base import TPOTBase, _has_cuml
 from tpot.driver import float_range

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -23,6 +23,7 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 """
 
+from errno import ESRMNT
 from tpot import TPOTClassifier, TPOTRegressor
 from tpot.base import TPOTBase, _has_cuml
 from tpot.driver import float_range
@@ -2465,3 +2466,24 @@ def test_clean_pipeline_string():
 
     pretty_string = tpot_obj.clean_pipeline_string(ind1)
     assert pretty_string == without_prefix
+
+def test_proba():
+    """Assert that TPOT's predict_proba is working correctly."""
+
+
+    X = np.random.rand(10,10)
+    y = np.random.randint(0,2,10)
+
+    est = TPOTClassifier(generations=1,population_size=1, template='LogisticRegression')
+    est.fit(X,y)
+    assert hasattr(est, "predict_proba") #This model has predict_proba
+    est.predict_proba(X)
+
+    est = TPOTClassifier(generations=1,population_size=1, template='LinearSVC')
+    with assert_raises(AttributeError) as cm: #This model is not fit and should raise an error
+        est.predict_proba(X)
+    est.fit(X,y)
+    assert not hasattr(est, "predict_proba") #This model does not have predict_proba, but it hasattr shouldn't raise an error
+    
+    with assert_raises(AttributeError) as cm: #This model does not have predict_proba so this should raise an error
+        est.predict_proba(X)

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -984,6 +984,18 @@ def test_predict_proba_5():
 
     assert result.shape == (features_with_nan.shape[0], num_labels)
 
+def test_predict_proba_6():
+    """Assert that TPOT's predict_proba is exposed when available, and hidden when not."""
+
+    est = TPOTClassifier(generations=1,population_size=1, template='LogisticRegression')
+    est.fit(training_features, training_target)
+    assert hasattr(est, "predict_proba") #This model has predict_proba
+    est.predict_proba(training_features)
+
+    est = TPOTClassifier(generations=1,population_size=1, template='LinearSVC')
+    est.fit(training_features, training_target)
+    assert not hasattr(est, "predict_proba") #This model does not have predict_proba, but it hasattr shouldn't raise an error
+
 
 def test_warm_start():
     """Assert that the TPOT warm_start flag stores the pop and pareto_front from the first run."""

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -53,6 +53,7 @@ from sklearn.preprocessing import FunctionTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.model_selection import train_test_split
 from sklearn.model_selection._split import check_cv
+from sklearn.utils.metaestimators import available_if
 
 from joblib import Parallel, delayed, Memory
 
@@ -1108,6 +1109,22 @@ class TPOTBase(BaseEstimator):
         )
         return score
 
+
+    def _check_proba(self):
+        if not hasattr(self, 'fitted_pipeline_'):
+            raise AttributeError(
+                "A pipeline has not yet been optimized. Please call fit() first."
+            )
+            
+        else:
+            if not (hasattr(self.fitted_pipeline_, "predict_proba")):
+                raise AttributeError(
+                    "The fitted pipeline does not have the predict_proba() function."
+                )
+            
+        return True
+
+    @available_if(_check_proba)
     def predict_proba(self, features):
         """Use the optimized pipeline to estimate the class probabilities for a feature set.
 
@@ -1122,19 +1139,9 @@ class TPOTBase(BaseEstimator):
             The class probabilities of the input samples
 
         """
-        if not self.fitted_pipeline_:
-            raise RuntimeError(
-                "A pipeline has not yet been optimized. Please call fit() first."
-            )
-        else:
-            if not (hasattr(self.fitted_pipeline_, "predict_proba")):
-                raise RuntimeError(
-                    "The fitted pipeline does not have the predict_proba() function."
-                )
-
-            features = self._check_dataset(features, target=None, sample_weight=None)
-
-            return self.fitted_pipeline_.predict_proba(features)
+    
+        features = self._check_dataset(features, target=None, sample_weight=None)
+        return self.fitted_pipeline_.predict_proba(features)
 
     def clean_pipeline_string(self, individual):
         """Provide a string of the individual without the parameter prefixes.


### PR DESCRIPTION
## What does this PR do?

This pull request makes predict_proba consistent with other sklearn methods. Previously the predict_proba method was exposed when the final pipeline does not have predict_proba, that is hasattr(est, "predict_proba") returns True, but throw a runtime error when called. The new behavior is that the method is hidden when not available. Now hasattr(est, "predict_proba") returns false when predict_proba is not available in the final pipeline. Additionally the error type is changed from runetimeerror to attributeerror


## Where should the reviewer start?

Note that changed the Runtimeerror to Attribute error since that is what the sklearn VotingClassifier and SVM methods used. I'm open to suggestions if another error would be more accurate.

## How should this PR be tested?

I added test_predict_proba_6() in tpot_tests.py in the test folder. The other test methods also test the same function. Theses were just updated to the new error type.

Also note that some unrelated tests fail due to deprecation in new versions of sklearn. Specifically sklearn.utils.testing is not sklearn.utils._testing in the more recent versions. That could be fixed in another pull request.

## Any background context you want to provide?

Other sklearn methods seem to not expose predict_proba when not available. For example, [VotingClassifier](https://github.com/scikit-learn/scikit-learn/blob/80598905e/sklearn/ensemble/_voting.py#L393) and [SVM](https://github.com/scikit-learn/scikit-learn/blob/4ca4f3bbcd6fb544d92886ce9690c001d8e75978/sklearn/svm/_base.py#L826). 

This allows users to treat tpot estimators the same as other estimators by using hasattr(est, "predict_proba") when checking if a particular model has that attribute. If this pull request is accepted, it could also be clarified in the documentation that this is an option. 

An alternative behavior would be to have predict_proba just default to predict() when probabilities are not available. However, if tpot would throw an error with predict_proba, the method should be hidden similar to the other methods in sklearn.

## What are the relevant issues?

This was mentioned in issues #1246 , #1170



## Questions:

- Do the docs need to be updated?
Yes, that would be helpful

- Does this PR add new (Python) dependencies?
no