### PR TITLE
Dask now uses njobs instead of all possible cores

### DIFF
--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -936,15 +936,16 @@ def test_predict_proba_2():
 
 
 def test_predict_proba_3():
-    """Assert that the TPOT predict_proba function raises a RuntimeError when no optimized pipeline exists."""
+    """Assert that the TPOT predict_proba function raises an AttributeError when no optimized pipeline exists."""
     tpot_obj = TPOTClassifier()
     tpot_obj._fit_init()
 
-    assert_raises(RuntimeError, tpot_obj.predict_proba, testing_features)
+    with assert_raises(AttributeError) as cm:
+        tpot_obj.predict_proba(testing_features)
 
 
 def test_predict_proba_4():
-    """Assert that the TPOT predict_proba function raises a RuntimeError when the optimized pipeline do not have the predict_proba() function"""
+    """Assert that the TPOT predict_proba function raises an AttributeError when the optimized pipeline do not have the predict_proba() function"""
     tpot_obj = TPOTRegressor()
     tpot_obj._fit_init()
     pipeline_string = (
@@ -957,7 +958,9 @@ def test_predict_proba_4():
     tpot_obj.fitted_pipeline_ = tpot_obj._toolbox.compile(expr=tpot_obj._optimized_pipeline)
     tpot_obj.fitted_pipeline_.fit(training_features_r, training_target_r)
 
-    assert_raises(RuntimeError, tpot_obj.predict_proba, testing_features)
+    with assert_raises(AttributeError) as cm:
+        tpot_obj.predict_proba(testing_features)
+    
 
 
 def test_predict_proba_5():

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -2468,24 +2468,3 @@ def test_clean_pipeline_string():
 
     pretty_string = tpot_obj.clean_pipeline_string(ind1)
     assert pretty_string == without_prefix
-
-def test_proba():
-    """Assert that TPOT's predict_proba is working correctly."""
-
-
-    X = np.random.rand(10,10)
-    y = np.random.randint(0,2,10)
-
-    est = TPOTClassifier(generations=1,population_size=1, template='LogisticRegression')
-    est.fit(X,y)
-    assert hasattr(est, "predict_proba") #This model has predict_proba
-    est.predict_proba(X)
-
-    est = TPOTClassifier(generations=1,population_size=1, template='LinearSVC')
-    with assert_raises(AttributeError) as cm: #This model is not fit and should raise an error
-        est.predict_proba(X)
-    est.fit(X,y)
-    assert not hasattr(est, "predict_proba") #This model does not have predict_proba, but it hasattr shouldn't raise an error
-    
-    with assert_raises(AttributeError) as cm: #This model does not have predict_proba so this should raise an error
-        est.predict_proba(X)

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -23,7 +23,6 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 """
 
-from errno import ESRMNT
 from tpot import TPOTClassifier, TPOTRegressor
 from tpot.base import TPOTBase, _has_cuml
 from tpot.driver import float_range

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -23,6 +23,7 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 """
 
+from errno import ESRMNT
 from tpot import TPOTClassifier, TPOTRegressor
 from tpot.base import TPOTBase, _has_cuml
 from tpot.driver import float_range
@@ -2465,3 +2466,24 @@ def test_clean_pipeline_string():
 
     pretty_string = tpot_obj.clean_pipeline_string(ind1)
     assert pretty_string == without_prefix
+
+def test_proba():
+    """Assert that TPOT's predict_proba is working correctly."""
+
+
+    X = np.random.rand(10,10)
+    y = np.random.randint(0,2,10)
+
+    est = TPOTClassifier(generations=1,population_size=1, template='LogisticRegression')
+    est.fit(X,y)
+    assert hasattr(est, "predict_proba") #This model has predict_proba
+    est.predict_proba(X)
+
+    est = TPOTClassifier(generations=1,population_size=1, template='LinearSVC')
+    with assert_raises(AttributeError) as cm: #This model is not fit and should raise an error
+        est.predict_proba(X)
+    est.fit(X,y)
+    assert not hasattr(est, "predict_proba") #This model does not have predict_proba, but it hasattr shouldn't raise an error
+    
+    with assert_raises(AttributeError) as cm: #This model does not have predict_proba so this should raise an error
+        est.predict_proba(X)

--- a/tests/tpot_tests.py
+++ b/tests/tpot_tests.py
@@ -984,6 +984,18 @@ def test_predict_proba_5():
 
     assert result.shape == (features_with_nan.shape[0], num_labels)
 
+def test_predict_proba_6():
+    """Assert that TPOT's predict_proba is exposed when available, and hidden when not."""
+
+    est = TPOTClassifier(generations=1,population_size=1, template='LogisticRegression')
+    est.fit(training_features, training_target)
+    assert hasattr(est, "predict_proba") #This model has predict_proba
+    est.predict_proba(training_features)
+
+    est = TPOTClassifier(generations=1,population_size=1, template='LinearSVC')
+    est.fit(training_features, training_target)
+    assert not hasattr(est, "predict_proba") #This model does not have predict_proba, but it hasattr shouldn't raise an error
+
 
 def test_warm_start():
     """Assert that the TPOT warm_start flag stores the pop and pareto_front from the first run."""

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -1561,10 +1561,10 @@ class TPOTBase(BaseEstimator):
                             ]
                         ]
 
-                        self.dask_graphs_ = tmp_result_scores
+                        
                         with warnings.catch_warnings():
                             warnings.simplefilter("ignore")
-                            tmp_result_scores = list(dask.compute(*tmp_result_scores))
+                            tmp_result_scores = list(dask.compute(*tmp_result_scores, num_workers=self.n_jobs))
 
                     else:
 

--- a/tpot/base.py
+++ b/tpot/base.py
@@ -53,6 +53,7 @@ from sklearn.preprocessing import FunctionTransformer
 from sklearn.impute import SimpleImputer
 from sklearn.model_selection import train_test_split
 from sklearn.model_selection._split import check_cv
+from sklearn.utils.metaestimators import available_if
 
 from joblib import Parallel, delayed, Memory
 
@@ -1108,6 +1109,22 @@ class TPOTBase(BaseEstimator):
         )
         return score
 
+
+    def _check_proba(self):
+        if not hasattr(self, 'fitted_pipeline_'):
+            raise AttributeError(
+                "A pipeline has not yet been optimized. Please call fit() first."
+            )
+            
+        else:
+            if not (hasattr(self.fitted_pipeline_, "predict_proba")):
+                raise AttributeError(
+                    "The fitted pipeline does not have the predict_proba() function."
+                )
+            
+        return True
+
+    @available_if(_check_proba)
     def predict_proba(self, features):
         """Use the optimized pipeline to estimate the class probabilities for a feature set.
 
@@ -1122,19 +1139,9 @@ class TPOTBase(BaseEstimator):
             The class probabilities of the input samples
 
         """
-        if not self.fitted_pipeline_:
-            raise RuntimeError(
-                "A pipeline has not yet been optimized. Please call fit() first."
-            )
-        else:
-            if not (hasattr(self.fitted_pipeline_, "predict_proba")):
-                raise RuntimeError(
-                    "The fitted pipeline does not have the predict_proba() function."
-                )
-
-            features = self._check_dataset(features, target=None, sample_weight=None)
-
-            return self.fitted_pipeline_.predict_proba(features)
+    
+        features = self._check_dataset(features, target=None, sample_weight=None)
+        return self.fitted_pipeline_.predict_proba(features)
 
     def clean_pipeline_string(self, individual):
         """Provide a string of the individual without the parameter prefixes.


### PR DESCRIPTION
## What does this PR do?

Dask now uses n_jobs instead of all possible cores. In dask.compute the parameters is now set as follows:  num_workers=self.n_jobs

Also removed the line `self.dask_graphs_ = tmp_result_scores` since this variable isn't actually used anywhere.

## Where should the reviewer start?



## How should this PR be tested?

est = tpot.TPOTClassifier(use_dask=True, n_jobs=1)
est = tpot.TPOTClassifier(use_dask=True, n_jobs=32)

and observe the CPU usage and time to completion.

## Any background context you want to provide?

Note that within a dask client context manager, the client parameters for n_workers is used rather than the n_jobs passed into tpot.

## What are the relevant issues?

#1223

## Screenshots (if appropriate)



## Questions:

- Do the docs need to be updated?

Might be helpful to demonstrate an example using localcluster, and dask joblib. When within a client context manager, n_jobs in dask.compute is actually ignored in favor of the LocalCluster parameters. Since this behavior is not obvious, I think it would be helpful to include in the docs.

For example:

```
with LocalCluster(threads_per_worker=32, n_workers=1, processes=False) as cluster:
    with Client(cluster) as client:
        with dask.distributed.performance_report():

            start = time.time()
            est = tpot.TPOTClassifier(use_dask=True)
            est.fit(X,y)
            t1 = time.time() - start
            print(t1)
```

- Does this PR add new (Python) dependencies?
no
