### PR TITLE
Update api.md

### DIFF
--- a/docs_sources/api.md
+++ b/docs_sources/api.md
@@ -93,7 +93,7 @@ Cross-validation strategy used when evaluating pipelines.
 <br /><br />
 Possible inputs:
 <ul>
-<li>integer, to specify the number of folds in a StratifiedKFold,</li>
+<li>integer, to specify the number of folds in an unshuffled StratifiedKFold,</li>
 <li>An object to be used as a cross-validation generator, or</li>
 <li>An iterable yielding train/test splits.</li>
 </blockquote>
@@ -601,7 +601,7 @@ Cross-validation strategy used when evaluating pipelines.
 <br /><br />
 Possible inputs:
 <ul>
-<li>integer, to specify the number of folds in a KFold,</li>
+<li>integer, to specify the number of folds in an unshuffled KFold,</li>
 <li>An object to be used as a cross-validation generator, or</li>
 <li>An iterable yielding train/test splits.</li>
 </ul>


### PR DESCRIPTION
just making it clearer that tpot does not shuffle data by default. Easy mistake to pass in sorted data assuming that tpot shuffles it.