### PR TITLE
Mate operator fix

### DIFF
--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -86,6 +86,8 @@ def _pre_test(func):
                 # returns tuple of (ind1, ind2)
 
                 expr_tuple = expr if isinstance(expr, tuple) else (expr,)
+                if func.__name__ == "_mate_operator":
+                    expr_tuple = expr_tuple[0:2]
                 for expr_test in expr_tuple:
                     pipeline_code = generate_pipeline_code(
                         expr_to_tree(expr_test, self._pset),


### PR DESCRIPTION


## What does this PR do?

_mate_operator has a wrapper that tries to check if all its returned values are valid pipelines. The last returned item is actually a dictionary and does not need to be evaluated. This led to the following error being thrown any time this function was called

_pre_test decorator: _mate_operator: num_test=0 'str' object has no attribute 'arity'.


I added a check in the decorator specific to _mate_operator to prevent this. Alternatively, We could also implement a generic check to skip anything that is not a pipeline/deap individual


