### PR TITLE
Fixed the error "assert_all_finite() takes 1 positional argument, 2 were given" in nn.py

### DIFF
--- a/tpot/builtins/nn.py
+++ b/tpot/builtins/nn.py
@@ -160,7 +160,8 @@ class PytorchClassifier(PytorchEstimator, ClassifierMixin):
 
         X, y = check_X_y(X, y, accept_sparse=False, allow_nd=False)
 
-        assert_all_finite(X, y)
+        # Checks if input contains NaN, infinity or a value too large for dtype('float64').
+        assert_all_finite(X)
 
         if type_of_target(y) != 'binary':
             raise ValueError("Non-binary targets not supported")


### PR DESCRIPTION
Fixed the error "assert_all_finite() takes 1 positional argument, but 2 were given" in `tpot/builtins/nn.py`. Reference : [link](https://scikit-learn.org/stable/modules/generated/sklearn.utils.assert_all_finite.html)