### PR TITLE
fixed the error "assert_all_finite() takes 1 positional argument, 2 were given"

### DIFF
--- a/tpot/builtins/nn.py
+++ b/tpot/builtins/nn.py
@@ -160,7 +160,9 @@ class PytorchClassifier(PytorchEstimator, ClassifierMixin):
 
         X, y = check_X_y(X, y, accept_sparse=False, allow_nd=False)
 
-        assert_all_finite(X, y)
+        # Throw a ValueError if X or y contains NaN or infinity.
+        assert_all_finite(X)
+        assert_all_finite(y)
 
         if type_of_target(y) != 'binary':
             raise ValueError("Non-binary targets not supported")


### PR DESCRIPTION
Fixed the error created in `tpot/builtins/nn.py` by assert_all_finite() function that takes 1 positional argument, but 2 were given.
Reference: [Link](https://scikit-learn.org/stable/modules/generated/sklearn.utils.assert_all_finite.html?highlight=assert_all_finite#sklearn.utils.assert_all_finite)