### PR TITLE
Replace `np.float` with `np.float64` in `one_hot_encoder`

### DIFF
--- a/tpot/builtins/one_hot_encoder.py
+++ b/tpot/builtins/one_hot_encoder.py
@@ -158,7 +158,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
         Non-categorical features are always stacked to the right of the matrix.
 
-    dtype : number type, default=np.float
+    dtype : number type, default=np.float64
         Desired dtype of output.
 
     sparse : boolean, default=True
@@ -213,7 +213,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
       encoding of dictionary items or strings.
     """
 
-    def __init__(self, categorical_features='auto', dtype=np.float,
+    def __init__(self, categorical_features='auto', dtype=np.float64,
                  sparse=True, minimum_fraction=None, threshold=10):
         self.categorical_features = categorical_features
         self.dtype = dtype


### PR DESCRIPTION
## Any background context you want to provide?
[NumPy 1.24.0](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations) removed the `np.float` alias, so we have to replace `np.float` with `np.float64` in `one_hot_encoder`.

Another option is to replace `np.float` with Python's `float`, although the NumPy version may be useful for consistency with NumPy arrays ([source](https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations)).