### PR TITLE
Update NumPy version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 deap>=1.2
 nose==1.3.7
-numpy>=1.16.3
+numpy>=1.16.3,<1.24.0
 scikit-learn>=0.22.0
 imbalanced-learn>=0.7.0
 scipy>=1.3.1


### PR DESCRIPTION
Update NumPy version requirement to be < 1.24.0 to avoid an AttributeError from importing TPOT in that and newer versions (#1281).  This PR may be superceded by #1280, or may need to be reverted in #1280, depending on review/merge order.

Newer releases of Numpy (and by extension, fresh installs of TPOT) are not compatible with the latest TPOT code and `requirements.txt`.  Several deprecated numpy aliases are [removed in Numpy 1.24.0](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations), and _at least_ one (`numpy.float`) is still used in the TPOT code.

Before this fix:

```
pip install -r requirements.txt
python
>>> import tpot
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mark.forrer/Documents/code/tpot/tpot/__init__.py", line 27, in <module>
    from .tpot import TPOTClassifier, TPOTRegressor
  File "/Users/mark.forrer/Documents/code/tpot/tpot/tpot.py", line 31, in <module>
    from .base import TPOTBase
  File "/Users/mark.forrer/Documents/code/tpot/tpot/base.py", line 71, in <module>
    from .builtins import CombineDFs, StackingEstimator
  File "/Users/mark.forrer/Documents/code/tpot/tpot/builtins/__init__.py", line 29, in <module>
    from .one_hot_encoder import OneHotEncoder, auto_select_categorical_features, _transform_selected
  File "/Users/mark.forrer/Documents/code/tpot/tpot/builtins/one_hot_encoder.py", line 136, in <module>
    class OneHotEncoder(BaseEstimator, TransformerMixin):
  File "/Users/mark.forrer/Documents/code/tpot/tpot/builtins/one_hot_encoder.py", line 216, in OneHotEncoder
    def __init__(self, categorical_features='auto', dtype=np.float,
  File "/Users/mark.forrer/.pyenv/versions/tpot/lib/python3.8/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'float'
```