### PR TITLE
Made MAX_EVAL_SECS configurable via environment

### DIFF
--- a/tpot/decorators.py
+++ b/tpot/decorators.py
@@ -25,15 +25,16 @@ License along with TPOT. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
 from functools import wraps
+import os
 import warnings
 from .export_utils import expr_to_tree, generate_pipeline_code
 from deap import creator
 
-from stopit import threading_timeoutable, TimeoutException
+from stopit import threading_timeoutable
 
 
 NUM_TESTS = 10
-MAX_EVAL_SECS = 10
+MAX_EVAL_SECS = int(os.environ.get('TPOT_MAX_EVAL_SECS') or 10)
 
 
 def _pre_test(func):
@@ -79,7 +80,7 @@ def _pre_test(func):
                     try:
                         expr = func(self, *args, **kwargs)
                         pass_gen = True
-                    except:
+                    except Exception:
                         num_test_expr += 1
                         pass
                 # mutation operator returns tuple (ind,); crossover operator
@@ -115,6 +116,5 @@ def _pre_test(func):
                 num_test += 1
 
         return expr
-
 
     return check_pipeline


### PR DESCRIPTION
[please review the [Contribution Guidelines](http://epistasislab.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?
 - `MAX_EVAL_SECS` value hardcoded as 10 seconds and I wanted to get it increased but no way. So made it configurable.


## Where should the reviewer start?
 - Simple. Just check the decorators.py


## How should this PR be tested?
 - No big change but anyone can configure the timeout raised by stopit. 


## Any background context you want to provide?
  - No background.


## What are the relevant issues?

 - #1088 
 - #1200

## Screenshots (if appropriate)
 - No screenshot


## Questions:

- Do the docs need to be updated? Maybe yes.
- Does this PR add new (Python) dependencies? No.
