### PR TITLE
Early crash fix

### DIFF
--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -141,7 +141,6 @@ def varOr(population, toolbox, lambda_, cxpb, mutpb):
                 # If there is no pair eligible for crossover, we still want to
                 # create diversity in the population, and do so by mutation instead.
                 ind_mu = mutate_random_individual(population, toolbox)
-                print(ind_mu.fitness.values)
                 offspring.append(ind_mu)
         elif op_choice < cxpb + mutpb:  # Apply mutation
             ind = mutate_random_individual(population, toolbox)

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -132,7 +132,7 @@ def varOr(population, toolbox, lambda_, cxpb, mutpb):
             ind1, ind2 = pick_two_individuals_eligible_for_crossover(population)
             if ind1 is not None:
                 ind1_cx, _, evaluated_individuals_= toolbox.mate(ind1, ind2)
-                del ind1.fitness.values
+                del ind1_cx.fitness.values
 
                 if str(ind1_cx) in evaluated_individuals_:
                     ind1_cx = mutate_random_individual(population, toolbox)
@@ -141,6 +141,7 @@ def varOr(population, toolbox, lambda_, cxpb, mutpb):
                 # If there is no pair eligible for crossover, we still want to
                 # create diversity in the population, and do so by mutation instead.
                 ind_mu = mutate_random_individual(population, toolbox)
+                print(ind_mu.fitness.values)
                 offspring.append(ind_mu)
         elif op_choice < cxpb + mutpb:  # Apply mutation
             ind = mutate_random_individual(population, toolbox)


### PR DESCRIPTION
[please review the [Contribution Guidelines](http://epistasislab.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

I believe this addresses the cause of the issue described in #1313 and #1308.

The issue in in line 134 and 137 of gp_deap.py

Original
```
if ind1 is not None:
                ind1, _ = toolbox.mate(ind1, ind2)
                del ind1.fitness.values
```

bugged

```
if ind1 is not None:
                ind1_cx, _, evaluated_individuals_= toolbox.mate(ind1, ind2)
                del ind1.fitness.values

```

fixed

```
if ind1 is not None:
                ind1_cx, _, evaluated_individuals_= toolbox.mate(ind1, ind2)
                del ind1_cx.fitness.values

```


In commit  9e6ad7e line 134 was changed to rename ind1 to ind1_cx. 
However the following line was not changed to rename ind1 to ind1_cx. So rather than deleting the values for the new individual, it was deleting the scores for the old individual. likely triggering the error identified by @Lingepumpe in #1308


## How should this PR be tested?

I used the following code to reproduce the behavior. It doesn't happen all of the time, needs to be rerun a few times to recreate the problem. The issue does not seem to happen with the fixed version.


```
from tpot import TPOTRegressor
from sklearn.model_selection import train_test_split
from sklearn.preprocessing import LabelEncoder
import pandas as pd
import numpy as np
import sklearn.datasets

X, y = sklearn.datasets.make_regression(n_samples=100)

est = TPOTRegressor(generations=50, population_size=28, cv=2, verbosity=2, random_state=42, n_jobs=-2)

est.fit(X,y)

```


## What are the relevant issues?

#1313  #1308

