### PR TITLE
remove deprecated imp, fix docstring warning

### DIFF
--- a/tpot/base.py
+++ b/tpot/base.py
@@ -28,7 +28,7 @@ import random
 import inspect
 import warnings
 import sys
-import imp
+
 from functools import partial
 from datetime import datetime
 from multiprocessing import cpu_count
@@ -38,7 +38,7 @@ import errno
 
 from tempfile import mkdtemp
 from shutil import rmtree
-
+import types
 import numpy as np
 from pandas import DataFrame
 from scipy import sparse
@@ -411,7 +411,7 @@ class TPOTBase(BaseEstimator):
     def _read_config_file(self, config_path):
         if os.path.isfile(config_path):
             try:
-                custom_config = imp.new_module("custom_config")
+                custom_config = types.ModuleType("custom_config")
 
                 with open(config_path, "r") as config_file:
                     file_string = config_file.read()

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -93,7 +93,7 @@ def mutate_random_individual(population, toolbox):
 
 
 def varOr(population, toolbox, lambda_, cxpb, mutpb):
-    """Part of an evolutionary algorithm applying only the variation part
+    r"""Part of an evolutionary algorithm applying only the variation part
     (crossover, mutation **or** reproduction). The modified individuals have
     their fitness invalidated. The individuals are cloned so returned
     population is independent of the input population.
@@ -177,7 +177,7 @@ def initialize_stats_dict(individual):
 def eaMuPlusLambda(population, toolbox, mu, lambda_, cxpb, mutpb, ngen, pbar,
                    stats=None, halloffame=None, verbose=0,
                    per_generation_function=None, log_file=None):
-    """This is the :math:`(\mu + \lambda)` evolutionary algorithm.
+    r"""This is the :math:`(\mu + \lambda)` evolutionary algorithm.
     :param population: A list of individuals.
     :param toolbox: A :class:`~deap.base.Toolbox` that contains the evolution
                     operators.


### PR DESCRIPTION
imp is deprecated in Python 12.  This was only used in one function which I replaced with the equivalent function found in the types module.

Also, the docstrings that contained backslashes were causing a warning to be called every time that was imported. These were probably intended for latex formatting, but Python reads them differently. I turned those into literal docstrings so that the Python interpretation of escape sequences was ignored, which stopped the warnings.