### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 deap>=1.2
 nose==1.3.7
 numpy>=1.16.3
-scikit-learn>=0.22.0
+scikit-learn>=1.0
 imbalanced-learn>=0.7.0
 scipy>=1.3.1
 tqdm>=4.36.1

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ This project is hosted at https://github.com/EpistasisLab/tpot
     zip_safe=True,
     install_requires=['numpy>=1.16.3',
                     'scipy>=1.3.1',
-                    'scikit-learn>=0.22.0',
+                    'scikit-learn>=1.0.0',
                     'deap>=1.2',
                     'update_checker>=0.16',
                     'tqdm>=4.36.1',


### PR DESCRIPTION
Due to the use of the decorator 
`sklearn.utils.metaestimators.available_if()` by TPOT, declare as the minimum version required of scikit-learn the version that introduced this decorator, that was 1.0.

## What does this PR do?
Update the requirements for TPOT.


## Where should the reviewer start?
This is just a value change.


## How should this PR be tested?
Verify that TPOT no longer works with scikit-learn version 0.22.0 or any other version prior to 1.0, but it works with version 1.0 and above.


## Any background context you want to provide?
I think none is needed.


## What are the relevant issues?
There are none, other than TPOT failing to work when all its stated requirements are satisfied.

## Screenshots (if appropriate)
None is provided.


## Questions:

- Do the docs need to be updated?

I think there is one reference that would benefit of attention in the installation section, despite referring to dask.

- Does this PR add new (Python) dependencies?

No, it does not.