### PR TITLE
update sklearn version to 1.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 deap>=1.2
 nose==1.3.7
 numpy>=1.16.3
-scikit-learn>=1.0
+scikit-learn>=1.1.3
 imbalanced-learn>=0.7.0
 scipy>=1.3.1
 tqdm>=4.36.1

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ This project is hosted at https://github.com/EpistasisLab/tpot
     zip_safe=True,
     install_requires=['numpy>=1.16.3',
                     'scipy>=1.3.1',
-                    'scikit-learn>=1.0.0',
+                    'scikit-learn>=1.1.3',
                     'deap>=1.2',
                     'update_checker>=0.16',
                     'tqdm>=4.36.1',


### PR DESCRIPTION
## What does this PR do?

updates the minimum version of sklearn to 1.1.3 . TPOT1. This is required for the get_scorer_names function used. 

This would resolve #1330
