### PR TITLE
update compatibility with scikitlearn 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 deap>=1.2
 nose==1.3.7
 numpy>=1.16.3
-scikit-learn>=1.1.3
+scikit-learn>=1.4.1
 imbalanced-learn>=0.7.0
 scipy>=1.3.1
 tqdm>=4.36.1

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ This project is hosted at https://github.com/EpistasisLab/tpot
     zip_safe=True,
     install_requires=['numpy>=1.16.3',
                     'scipy>=1.3.1',
-                    'scikit-learn>=1.1.3',
+                    'scikit-learn>=1.4.1',
                     'deap>=1.2',
                     'update_checker>=0.16',
                     'tqdm>=4.36.1',

--- a/tpot/gp_deap.py
+++ b/tpot/gp_deap.py
@@ -464,7 +464,8 @@ def _wrapped_cross_val_score(sklearn_pipeline, features, target,
                                          verbose=0,
                                          parameters=None,
                                          error_score='raise',
-                                         fit_params=sample_weight_dict)
+                                         fit_params=sample_weight_dict,
+                                         score_params=None)
                                     for train, test in cv_iter]
                 if isinstance(scores[0], list): #scikit-learn <= 0.23.2
                     CV_score = np.array(scores)[:, 0]


### PR DESCRIPTION
[please review the [Contribution Guidelines](http://epistasislab.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

This resolves the error encountered in #1341 . The latest version of sklearn updated the internal function  `def _fit_and_score` to take in an additional score_params parameter. When TPOT attempted to evaluate a pipeline with this function, it would throw an error because this parameter was missing. 

The parameter was introduced in this PR https://github.com/scikit-learn/scikit-learn/pull/26896/files

## How should this PR be tested?

I tested with the following code. Runs with the fix but not without the fix.
```
from tpot import TPOTClassifier
from sklearn.datasets import load_iris
from sklearn.model_selection import train_test_split
import numpy as np

iris = load_iris()
X_train, X_test, y_train, y_test = train_test_split(iris.data.astype(np.float64),
    iris.target.astype(np.float64), train_size=0.75, test_size=0.25, random_state=42)

est = TPOTClassifier(generations=5, population_size=50, verbosity=2, random_state=42)
est.fit(X_train, y_train) 
```


## Questions:

- Do the docs need to be updated?
- Does this PR add new (Python) dependencies?

Updates the dependencies of scikit learn to version 1.4 . This change is incompatible with previous versions of scikit-learn
