### PR TITLE
fix fss node not returning T/F and not handling cases with only one f…

### DIFF
--- a/tpot/search_spaces/nodes/fss_node.py
+++ b/tpot/search_spaces/nodes/fss_node.py
@@ -109,14 +109,21 @@ class FSSIndividual(SklearnIndividual):
     def mutate(self, rng=None):
         rng = np.random.default_rng(rng)
         #get list of names not including the current one
-        names = [name for name in self.names_list if name != self.selected_subset_name]
-        self.selected_subset_name = rng.choice(names)
-        self.sel_subset = self.subset_dict[self.selected_subset_name]
+        if len(self.names_list)>1:
+            names = [name for name in self.names_list if name != self.selected_subset_name]
+            self.selected_subset_name = rng.choice(names)
+            self.sel_subset = self.subset_dict[self.selected_subset_name]
+            return True
+        else:
+            return False
         
     
     def crossover(self, other, rng=None):
+        if self.selected_subset_name == other.selected_subset_name:
+            return False
         self.selected_subset_name = other.selected_subset_name
         self.sel_subset = other.sel_subset
+        return True
 
     def export_pipeline(self, **kwargs):
         return FeatureSetSelector(sel_subset=self.sel_subset, name=self.selected_subset_name)


### PR DESCRIPTION
## What does this PR do?

FSSNode was not returning True or False for the mutation/crossover operations as required. 
Additionally, when only a single feature set was passed in, there would be an error thrown. This was found in issue #1366 
## Where should the reviewer start?



## How should this PR be tested?

```
subset_1_dict  = { "sense_strands" :  ['a', 'b', 'c']}
fss_1 = FSSNode(subsets=subset_1_dict)

ind1 = fss_1.generate()

for i in range(1000):
    ind1.mutate()
```

Before this would throw an error like : 

`File "/scratch2/users/mpb703/conda_environments/tpot_v1/lib/python3.10/site-packages/tpot/search_spaces/nodes/fss_node.py", line 113, in mutate self.selected_subset_name = rng.choice(names) File "numpy/random/_generator.pyx", line 803, in numpy.random._generator.Generator.choice ValueError: a cannot be empty unless no samples are take `
