### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ conda activate tpotenv
 
 ### Packages Used
 
-python version <3.12
+python version >=3.10, <3.13
 numpy
 scipy
 scikit-learn

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ conda activate tpotenv
 
 ### Packages Used
 
-python version >=3.10, <3.13
+python version >=3.10, <3.14
 numpy
 scipy
 scikit-learn

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ We recommend using conda environments for installing TPOT, though it would work 
 [More information on making anaconda environments found here.](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
 
 ```
-conda create --name tpotenv python=3.12
+conda create --name tpotenv python=3.13
 conda activate tpotenv
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ We recommend using conda environments for installing TPOT, though it would work 
 [More information on making anaconda environments found here.](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
 
 ```
-conda create --name tpotenv python=3.10
+conda create --name tpotenv python=3.12
 conda activate tpotenv
 ```
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,3 +3,4 @@ tox==4.4.12
 pytest==7.3.0
 pytest-cov==4.0.0
 mypy==1.2.0
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ package_version = calculate_version()
 
 setup(
     name='TPOT',
-    python_requires='>=3.10, <3.13',
+    python_requires='>=3.10, <3.14',
     version=package_version,
     author='Pedro Ribeiro',
     packages=find_packages(),
@@ -62,6 +62,7 @@ A Python tool that automatically creates and optimizes machine learning pipeline
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Scientific/Engineering :: Artificial Intelligence'
     ],
     keywords=['pipeline optimization', 'hyperparameter optimization', 'data science', 'machine learning', 'genetic programming', 'evolutionary computation'],

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ package_version = calculate_version()
 
 setup(
     name='TPOT',
-    python_requires='>=3.10, <3.12', #for configspace compatibility
+    python_requires='>=3.10, <3.13',
     version=package_version,
     author='Pedro Ribeiro',
     packages=find_packages(),
@@ -60,6 +60,8 @@ A Python tool that automatically creates and optimizes machine learning pipeline
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Scientific/Engineering :: Artificial Intelligence'
     ],
     keywords=['pipeline optimization', 'hyperparameter optimization', 'data science', 'machine learning', 'genetic programming', 'evolutionary computation'],

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,14 @@
 minversion = 3.28.0
 # flake8 and mypy outputs severla errors, so we disable them for now
 # envlist = py310, flake8, mypy
-envlist = py310
+envlist = py310, py311, py312
 isolated_build = true
 
 [gh-actions]
 python =
     3.10: py310
+    3.11: py311
+    3.12: py312
     # 3.10: py310, flake8, mypy
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 3.28.0
 # flake8 and mypy outputs severla errors, so we disable them for now
 # envlist = py310, flake8, mypy
-envlist = py310, py311, py312
+envlist = py310, py311, py312, py313
 isolated_build = true
 
 [gh-actions]
@@ -10,6 +10,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
     # 3.10: py310, flake8, mypy
 
 [testenv]

--- a/tpot/config/tests/test_get_configspace.py
+++ b/tpot/config/tests/test_get_configspace.py
@@ -1,5 +1,6 @@
 import pytest
 import tpot
+import sys
 from sklearn.datasets import load_iris
 import random
 import sklearn
@@ -24,6 +25,7 @@ def test_loop_through_all_hyperparameters():
             estnode = estnode_gen.generate()
             est = estnode.export_pipeline()
     
+@pytest.mark.skipif(sys.platform == 'darwin', reason="sklearnex dependency not available on macOS")
 def test_loop_through_groupnames():
 
     n_classes=3


### PR DESCRIPTION
## What does this PR do?

This PR adds support for Python 3.13 to TPOT and updates the CI workflow to test against Python 3.10, 3.11, 3.12, and 3.13.

**Note:** While basic checks (i.e. installing ConfigSpace into a 3.13 environment + running the examples listed on their docs page) for the core dependency `ConfigSpace` do work without error under Python 3.13, it has not yet officially declared Python 3.13 support via PyPI classifiers. I will see if I can put in a PR on their side to fix that.

Specifically, this PR modifies:
- `setup.py`: Updates `python_requires` to allow Python 3.13 (`<3.14`) and adds the 3.13 classifier.
- `.github/workflows/tests.yml`: Adds Python 3.13 to the CI test matrix.
- `tox.ini`: Adds `py313` to the default `envlist` and `[gh-actions]` mapping for consistency.
- `README.md`: Updates the listed supported Python version range.
- `docs/installation.md`: Updates the example conda environment command to use Python 3.13.

## Where should the reviewer start?

1.  `setup.py` for the `python_requires` and classifier changes.
2.  `.github/workflows/tests.yml` for the added CI test matrix entry.
3.  Other documentation/config files (`tox.ini`, `README.md`, `docs/installation.md`) for consistency updates.

## How should this PR be tested?

The primary testing is handled by the updated GitHub Actions CI workflow, which now runs `tox` (executing `pytest`) across Python 3.10, 3.11, 3.12, and 3.13 on Ubuntu.

Local testing was performed in a Python 3.13 conda environment on macOS arm64. All tests passed, with one test skipped (`test_loop_through_groupnames`) due to unavailable optional dependencies (`sklearnex`) on this platform. CI results should be monitored closely for any new failures specific to the Python 3.13 environment.

## Any background context you want to provide?

- This follows my PR #1374 which added Python 3.12 support.
- Basic local checks suggest `ConfigSpace` installs and runs simple examples on Python 3.13, but full compatibility is not guaranteed until officially declared by the `ConfigSpace` project.

## What are the relevant issues?

#1376 

## Questions:

- Do the docs need to be updated? **Yes, `README.md` and `docs/installation.md` were updated.**
- Does this PR add new (Python) dependencies? **No.**