### PR TITLE
bugfixes: feature selection mutation removal; early stop threshold scoring; misc.

### DIFF
--- a/tpot/evolvers/base_evolver.py
+++ b/tpot/evolvers/base_evolver.py
@@ -890,8 +890,8 @@ class BaseEvolver():
                     threshold = thresholds[step]
                     invalids = []
                     for i in range(len(offspring_scores)):
-
-                        if all([s*w>t*w for s,t,w in zip(offspring_scores[i],threshold,objective_function_signs)  ]):
+                        # fix: 'not' needed to fix logic (bug in original TPOT code meaning threshold logic was inverted); >= to make this work for scores that might be the same across all individuals in certain cases (e.g. on first of multiple stateful runs)
+                        if not all([s*w>=t*w for s,t,w in zip(offspring_scores[i],threshold,objective_function_signs)  ]):
                             invalids.append(i)
 
                     if len(invalids) > 0:
@@ -908,7 +908,7 @@ class BaseEvolver():
                 # Remove based on selection
                 if survival_counts is not None:
                     if step < self.evaluation_early_stop_steps - 1 and survival_counts[step]>1: #don't do selection for the last loop since they are completed
-                        k = survival_counts[step] + len(invalids) #TODO can remove the min if the selections method can ignore k>population size
+                        k = survival_counts[step] # ambiguous which invalids objects from above this is supposed to refer to; removed (tbc)
                         if len(cur_individuals)> 1 and k > self.n_jobs and k < len(cur_individuals):
                             weighted_scores = np.array([s * self.objective_function_weights for s in offspring_scores ])
 

--- a/tpot/search_spaces/nodes/genetic_feature_selection.py
+++ b/tpot/search_spaces/nodes/genetic_feature_selection.py
@@ -183,8 +183,9 @@ class GeneticFeatureSelectorIndividual(SklearnIndividual):
         p = to_remove / num_pos
         p = min(p, .5)
 
-        remove_mask = rng.choice([True, False], size=self.mask.shape, p=[p,1-p])
-        self.mask = np.logical_and(self.mask, remove_mask)
+        # bugfix for logic flaw
+        keep_mask = rng.choice([False, True], size=self.mask.shape, p=[p,1-p])
+        self.mask = np.logical_and(self.mask, keep_mask)
 
 
         if sum(self.mask) == 0:

--- a/tpot/tpot_estimator/estimator.py
+++ b/tpot/tpot_estimator/estimator.py
@@ -657,7 +657,7 @@ class TPOTEstimator(BaseEstimator):
 
 
         if self.threshold_evaluation_pruning is not None or self.selection_evaluation_pruning is not None:
-            evaluation_early_stop_steps = self.cv
+            evaluation_early_stop_steps = n_folds # fix to work with cv object instead of int
         else:
             evaluation_early_stop_steps = None
 


### PR DESCRIPTION
Addresses several logic bugs, fixing threshold early stopping and mutations in genetic feature selection, as well as miscellaneous other.

Bugfixes:

* Fix inverted threshold logic in early stopping during population selection by adding a `not` and using `>=` for correct comparison in `evaluate_population_selection_early_stop` (`base_evolver.py`).
* Fix logic flaw in the mutation mask so that features are correctly kept or removed in `_mutate_remove` (`genetic_feature_selection.py`).
* Remove ambiguity in selection count in `evaluate_population_selection_early_stop` (`base_evolver.py`).

Compatibility:

* Updated the determination of early stop steps to use `n_folds` for compatibility with cross-validation objects instead of raw integers in `objective_function` (`estimator.py`).